### PR TITLE
Fixes in troglitazone example

### DIFF
--- a/src/MScausality/graph_construction/indra_queries.py
+++ b/src/MScausality/graph_construction/indra_queries.py
@@ -168,8 +168,8 @@ def format_query_results(
                       ] if relation_mapper.get(relation.rel_type, 'evidence_count'
                                                ) in relation.data.keys() else None,
         relation.data["belief"] if "belief" in relation.data.keys() else None,
-        sum(json.loads(relation.data["source_counts"]).values()
-            ) if "source_counts" in relation.data.keys() else None,
+        json.loads(relation.data["source_counts"]) \
+            if "source_counts" in relation.data.keys() else None,
         json.loads(relation.data['stmt_json']
                 )['evidence'][0]['text_refs'] if \
                     "stmt_json" in relation.data.keys() \


### PR DESCRIPTION
This PR fixes a couple of issues: drop_duplicates not correctly parameterized and the source/target ID column name being inconsistent with the query implementation. It also adds a return value for the function and adds some prints to follow what is happening. Note that currently two and three-step queries don't resolve due to size.