### PR TITLE
Add test suite, CI/codecov, and packaging docs; fix two latent bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint (black + isort)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install lint tools
+        run: pip install black isort
+      - name: Check formatting
+        run: |
+          black --check src/ tests/
+          isort --check-only src/ tests/
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package with dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run tests
+        run: pytest --cov=causomic --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          flags: py${{ matrix.python-version }}
+          name: causomic-py${{ matrix.python-version }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,10 @@ cython_debug/
 
 .DS_Store
 .vscode/
+
+# Claude Code local files
+.claude/
+
+# Local model checkpoints and stray plot artifacts
+checkpoints/
+output.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `LICENSE` file (MIT).
+- `CONTRIBUTING.md` with development setup and contribution guidelines.
+- `CHANGELOG.md`.
+- `dev` and `test` optional-dependency groups in `pyproject.toml`.
+- pytest configuration (`[tool.pytest.ini_options]`) so the suite is discoverable
+  without manual `sys.path` manipulation.
+- Continuous integration workflow (GitHub Actions) running linting and tests.
+
+### Changed
+- Reconciled the supported Python range in `pyproject.toml` with the project's
+  actual development environment.
+
+## [0.0.1-dev] - 2024
+
+- Initial development release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to Causomic
+
+Thanks for your interest in contributing! This document explains how to set up a
+development environment, the conventions we follow, and how to submit changes.
+
+## Development setup
+
+Causomic targets Python 3.10–3.11 and depends on PyTorch 2.0.1 and Pyro. We
+recommend a clean virtual environment.
+
+```bash
+git clone https://github.com/Vitek-Lab/Causomic.git
+cd Causomic
+
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+
+# Install the package together with the development tooling
+pip install -e ".[dev]"
+```
+
+The `dev` extra installs everything needed to run the test suite and the
+formatting/linting tools. Some dependencies (e.g. `indra`, `indra-cogex`) are
+installed directly from GitHub and require network access.
+
+## Running the tests
+
+```bash
+pytest                 # run the full suite
+pytest --cov=causomic  # with coverage
+```
+
+Tests live in `tests/` and should not require network access or external
+databases (Neo4j, INDRA REST). Mock those boundaries instead.
+
+## Code style
+
+We use [Black](https://black.readthedocs.io/) for formatting and
+[isort](https://pycqa.github.io/isort/) for import ordering, configured in
+`pyproject.toml` (line length 100).
+
+```bash
+black src/ tests/
+isort src/ tests/
+```
+
+Please run both before opening a pull request. The CI workflow checks formatting
+and will fail if files are not formatted.
+
+## Submitting changes
+
+1. Fork the repository and create a feature branch:
+   `git checkout -b feature/short-description`
+2. Make your changes, including tests and docstrings for new functionality.
+3. Ensure `black`, `isort`, and `pytest` all pass locally.
+4. Update `CHANGELOG.md` under the `[Unreleased]` section.
+5. Open a pull request describing the change and its motivation.
+
+## Reporting issues
+
+Please use the [issue tracker](https://github.com/Vitek-Lab/Causomic/issues)
+and include a minimal reproducible example where possible.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Devon Kohler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 <p align="center">
-  <img src="https://github.com/devonjkohler/Causomic/blob/main/data/images/logo.png" height="150">
+  <img src="https://github.com/Vitek-Lab/Causomic/blob/main/data/images/logo.png" height="150">
 </p>
 
 # Causomic
 
-[![Python Version](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11-blue.svg)](https://www.python.org/downloads/)
+[![codecov](https://codecov.io/gh/Vitek-Lab/Causomic/branch/main/graph/badge.svg)](https://codecov.io/gh/Vitek-Lab/Causomic)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Development Status](https://img.shields.io/badge/status-development-orange.svg)](https://github.com/devonjkohler/CausOmic)
+[![Development Status](https://img.shields.io/badge/status-development-orange.svg)](https://github.com/Vitek-Lab/Causomic)
 
 **Causal inference methods for -omics research**
 
@@ -73,13 +74,13 @@ The package is particularly useful for:
 ## Installation
 
 ### Prerequisites
-- Python 3.11
+- Python 3.10 or 3.11
 - PyTorch 2.0.1
 - Pyro-PPL
 
 ### Install from source
 ```bash
-git clone https://github.com/devonjkohler/Causomic.git
+git clone https://github.com/Vitek-Lab/Causomic.git
 cd Causomic
 pip install -e .
 ```
@@ -212,7 +213,7 @@ We welcome contributions! Please see our contributing guidelines:
 
 ### Development Setup
 ```bash
-git clone https://github.com/devonjkohler/Causomic.git
+git clone https://github.com/Vitek-Lab/Causomic.git
 cd Causomic
 pip install -e ".[dev]"
 ```
@@ -233,7 +234,7 @@ If you use Causomic in your research, please cite:
   title={Causomic: Causal inference methods for -omics research},
   author={Kohler, Devon},
   year={2024},
-  url={https://github.com/devonjkohler/Causomic},
+  url={https://github.com/Vitek-Lab/Causomic},
   version={0.0.1-dev}
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ name = "causomic"
 version = "0.0.1-dev"
 description = "Python code for causal modeling of proteomics data."
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = "==3.11.*"
+license = { text = "MIT" }
+requires-python = ">=3.10,<3.12"
 
 authors = [
 	{ name = "Devon Kohler", email = "kohler.d@northeastern.edu" },
@@ -41,16 +42,26 @@ dependencies = [
 	"namedlist",
 	"py3compat",
 	"python-dotenv",
+	"gseapy",
 ]
 
 [project.urls]
-Homepage = "https://github.com/devonjkohler/CausOmic"
-"Bug Tracker" = "https://github.com/devonjkohler/CausOmic/issues"
-"Source Code" = "https://github.com/devonjkohler/CausOmic"
+Homepage = "https://github.com/Vitek-Lab/Causomic"
+"Bug Tracker" = "https://github.com/Vitek-Lab/Causomic/issues"
+"Source Code" = "https://github.com/Vitek-Lab/Causomic"
 
 [project.optional-dependencies]
 notears = [
 	"notears @ git+https://github.com/xunzheng/notears.git",
+]
+test = [
+	"pytest>=7",
+	"pytest-cov",
+]
+dev = [
+	"causomic[test]",
+	"black",
+	"isort",
 ]
 
 [tool.setuptools]
@@ -61,9 +72,14 @@ package-dir = { "" = "src" }
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+pythonpath = ["src"]
+
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310"]
+target-version = ["py310", "py311"]
 
 [tool.isort]
 profile = "black"

--- a/src/causomic/causal_model/LVM.py
+++ b/src/causomic/causal_model/LVM.py
@@ -59,8 +59,6 @@ numpyro.set_host_device_count(4)
 # else:
 device = "cpu"  # torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-print(f"Using device: {device}")
-
 
 @dataclass
 class ScaleStats:
@@ -789,7 +787,9 @@ class LVM:
         pyro.set_rng_seed(1234)
 
         # Initialize the model
-        model_cls = StochasticEdgeProteomicModel if self.stochastic_edges else ProteomicPerturbationModel
+        model_cls = (
+            StochasticEdgeProteomicModel if self.stochastic_edges else ProteomicPerturbationModel
+        )
         model = model_cls(
             n_obs=len(self.input_data),
             root_nodes=self.root_nodes,
@@ -909,7 +909,7 @@ class LVM:
 
         if verbose and steps_no_improve < self.patience:
             print(f"Training completed at step {self.num_steps} (best ema {best_ema:.4f})")
-            
+
         self.model = model
         self.guide = guide
 
@@ -941,8 +941,9 @@ class LVM:
             raise AttributeError("Model must be fitted before adding imputed values")
 
         # Convert data to long format for easier manipulation
-        long_data = pd.melt(self._from_z(self.input_data), 
-                            var_name="protein", value_name="intensity")
+        long_data = pd.melt(
+            self._from_z(self.input_data), var_name="protein", value_name="intensity"
+        )
 
         # Replace zeros (used for missing values in model) with NaN
         long_data.loc[long_data["intensity"] == 0, "intensity"] = np.nan
@@ -979,8 +980,7 @@ class LVM:
                     imputed_values = imputation_long.loc[
                         imputation_long["protein"] == protein, "imp_loc"
                     ].values
-                    converted = self._from_z(
-                        pd.DataFrame(imputed_values, columns = [protein]))
+                    converted = self._from_z(pd.DataFrame(imputed_values, columns=[protein]))
                     long_data.loc[mask, "imp_mean"] = converted[protein].values
 
         elif self.backend == "numpyro":
@@ -1372,153 +1372,3 @@ class LVM:
         # Extract outcome predictions
         self.posterior_samples = baseline_predictions[outcome_node]
         self.intervention_samples = intervention_predictions[outcome_node]
-
-
-def main() -> None:
-    """
-    Example usage and testing of the LVM class.
-
-    This function demonstrates a complete workflow using the LVM for causal
-    inference on a simulated mediator model. It shows:
-    1. Data simulation with missing values
-    2. Data processing and normalization
-    3. Model fitting with Pyro backend
-    4. Intervention analysis
-    5. Visualization of results
-    """
-    import matplotlib.pyplot as plt
-
-    from causomic.simulation.example_graphs import mediator, signaling_network
-
-    print("=== LVM Example Workflow ===")
-
-    # Generate mediator graph and simulate data
-    print("1. Generating mediator model and simulating data...")
-    med_graph = signaling_network(add_independent_nodes=False)  # , output_node=True)
-
-    simulated_data = simulate_data(
-        med_graph["Networkx"],
-        coefficients=med_graph["Coefficients"],
-        add_error=False,
-        mnar_missing_param=[-5, 0.4],  # Missing not at random
-        add_feature_var=True,
-        n=100,
-        seed=2,
-    )
-
-    # Process feature-level data to protein-level
-    print("2. Processing feature-level data...")
-    input_data = dataProcess(
-        simulated_data["Feature_data"],
-        normalization=False,
-        summarization_method="TMP",
-        MBimpute=False,
-        sim_data=True,
-    )
-
-    # input_data.loc[:, "Output"] = simulated_data["Protein_data"]["Output"]
-
-    # Fit LVM model
-    print("4. Fitting LVM model with Pyro backend...")
-    lvm = LVM(backend="pyro", num_steps=2000, verbose=True)
-    lvm.fit(input_data, med_graph["causomic"])
-
-    # Perform intervention analysis
-    print("5. Performing intervention analysis...")
-    intervention_value = 3.0
-    lvm.intervention({"X": intervention_value}, ["M1", "Z"])
-
-    # Process imputed data for visualization
-    print("6. Processing imputed data...")
-    imputed_data = lvm.imputed_data.copy()
-    imputed_data["intensity"] = np.where(
-        imputed_data["was_missing"], imputed_data["imp_mean"], imputed_data["intensity"]
-    )
-
-    # Create wide format for plotting
-    imputed_data["index"] = np.tile(
-        np.arange(1, len(input_data) + 1), len(imputed_data["protein"].unique())
-    )
-    lvm_imputed = imputed_data.pivot(index="index", columns="protein", values="intensity")
-
-    # Visualization 1: Imputed vs Original Data
-    print("7. Creating visualizations...")
-    plt.figure(figsize=(12, 5))
-
-    plt.subplot(1, 2, 1)
-    missing_indices = imputed_data[imputed_data["was_missing"]]["index"].unique()
-    colors = ["red" if idx in missing_indices else "blue" for idx in lvm_imputed.index]
-
-    plt.scatter(lvm_imputed["M1"], lvm_imputed["Z"], alpha=0.6, c=colors, s=20)
-    plt.xlabel("M1 (Mediator)")
-    plt.ylabel("Z (Outcome)")
-    plt.title("M1 vs Z\n(Red: Imputed, Blue: Observed)")
-    plt.grid(True, alpha=0.3)
-
-    # Visualization 2: Distribution by Output
-    plt.subplot(1, 2, 2)
-    for output_val in sorted(input_data["Output"].unique()):
-        subset = input_data[input_data["Output"] == output_val]
-        plt.hist(subset["X"], bins=20, alpha=0.6, label=f"Output={output_val}")
-
-    plt.xlabel("X (Treatment)")
-    plt.ylabel("Count")
-    plt.title("Distribution of X by Output")
-    plt.legend()
-    plt.grid(True, alpha=0.3)
-
-    plt.tight_layout()
-    plt.show()
-
-    # Intervention analysis across multiple values
-    print("8. Analyzing intervention effects across values...")
-    intervention_values = [0, 1, 2, 3, 4, 5, 6]
-    intervention_results = []
-
-    for value in intervention_values:
-        lvm.intervention({"X": value}, "Output")
-        mean_effect = lvm.intervention_samples.mean()
-        std_effect = lvm.intervention_samples.std()
-        intervention_results.append((value, mean_effect, std_effect))
-
-    # Plot intervention effects
-    plt.figure(figsize=(10, 6))
-    values, means, stds = zip(*intervention_results)
-
-    plt.errorbar(
-        values,
-        means,
-        yerr=stds,
-        fmt="o-",
-        capsize=5,
-        color="royalblue",
-        ecolor="darkorange",
-        linewidth=2,
-        markersize=8,
-        markeredgewidth=2,
-    )
-
-    plt.xlabel("Intervention Value (X)", fontsize=12)
-    plt.ylabel("Expected Outcome (Output)", fontsize=12)
-    plt.title("Causal Effect of X on Output", fontsize=14, fontweight="bold")
-    plt.grid(True, alpha=0.3)
-    plt.tight_layout()
-    plt.show()
-
-    print(f"\n=== Results Summary ===")
-    print(f"Model fitted with {len(lvm)} observations")
-    print(f"Missing data imputed: {lvm.imputed_data['was_missing'].sum():.0f} values")
-    print(f"Intervention effects range: {min(means):.3f} to {max(means):.3f}")
-    print("Analysis completed successfully!")
-
-    # import pickle
-    # with open("/Users/kohler.d/Library/CloudStorage/OneDrive-NortheasternUniversity/Northeastern/Research/Causal_Inference/AstraZeneca_project/case_studies/compounds/lvm_model.pkl", "rb") as file:
-    #     lvm = pickle.load(file)
-
-    # test = lvm.intervention({"NQO1" : 5},
-    #                  "SOD1", predictive_samples=100)
-    # print(test)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/causal_model/__init__.py
+++ b/src/causomic/causal_model/__init__.py
@@ -1,0 +1,17 @@
+"""Causal models for proteomics perturbation data.
+
+Exposes the latent-variable model used to fit causal graphs and predict
+intervention effects, along with the underlying Pyro model definitions.
+"""
+
+from causomic.causal_model.LVM import LVM
+from causomic.causal_model.models import (
+    ProteomicPerturbationModel,
+    StochasticEdgeProteomicModel,
+)
+
+__all__ = [
+    "LVM",
+    "ProteomicPerturbationModel",
+    "StochasticEdgeProteomicModel",
+]

--- a/src/causomic/causal_model/models.py
+++ b/src/causomic/causal_model/models.py
@@ -114,7 +114,7 @@ class ProteomicPerturbationModel(PyroModule):
                     ),
                 )
 
-            if node_name not in "Output":
+            if "Output" not in node_name:
                 downstream_coef_dict_scale[f"{node_name}_scale"] = pyro.sample(
                     f"{node_name}_scale", pyro_dist.Exponential(torch.tensor(1.0, device=device))
                 )
@@ -317,7 +317,7 @@ class StochasticEdgeProteomicModel(PyroModule):
                     edge_prob = torch.tensor(edge_prob, dtype=torch.float32, device=device)
                 edge_probs[f"{node_name}_{item}_edge"] = edge_prob
 
-            if node_name not in "Output":
+            if "Output" not in node_name:
                 downstream_coef_dict_scale[f"{node_name}_scale"] = pyro.sample(
                     f"{node_name}_scale", pyro_dist.Exponential(torch.tensor(1.0, device=device))
                 )

--- a/src/causomic/data_analysis/__init__.py
+++ b/src/causomic/data_analysis/__init__.py
@@ -1,0 +1,45 @@
+"""Proteomics data processing and downstream analysis.
+
+Includes MS data preprocessing (normalization, summarization, imputation),
+gene-set/correlation analysis, and pathway over-representation analysis.
+"""
+
+from causomic.data_analysis.gene_set import (
+    gen_correlation_matrix,
+    prep_msstats_data,
+    test_gene_sets,
+)
+from causomic.data_analysis.pathway_analysis import (
+    build_membership_matrix,
+    coverage_greedy_select,
+    export_to_cytoscape,
+    fetch_pathway_library,
+    list_pathway_libraries,
+    run_ora,
+    select_diverse_pathways,
+)
+from causomic.data_analysis.proteomics_data_processor import (
+    dataProcess,
+    format_sim_data,
+    imputation,
+    normalize_median,
+    summarize_data,
+)
+
+__all__ = [
+    "build_membership_matrix",
+    "coverage_greedy_select",
+    "dataProcess",
+    "export_to_cytoscape",
+    "fetch_pathway_library",
+    "format_sim_data",
+    "gen_correlation_matrix",
+    "imputation",
+    "list_pathway_libraries",
+    "normalize_median",
+    "prep_msstats_data",
+    "run_ora",
+    "select_diverse_pathways",
+    "summarize_data",
+    "test_gene_sets",
+]

--- a/src/causomic/data_analysis/gene_set.py
+++ b/src/causomic/data_analysis/gene_set.py
@@ -84,7 +84,10 @@ def parse_protein_name(
 
 
 def prep_msstats_data(
-    data: pd.DataFrame, parse_gene: bool = False, gene_map: Optional[pd.DataFrame] = None
+    data: pd.DataFrame,
+    parse_gene: bool = False,
+    gene_map: Optional[pd.DataFrame] = None,
+    verbose: bool = True,
 ) -> pd.DataFrame:
     """
     Prepare MSstats data for correlation analysis by formatting and reshaping.
@@ -139,10 +142,11 @@ def prep_msstats_data(
     # Check for duplicate entries before pivoting
     duplicates = pivot_data.duplicated(subset=["Protein", "originalRUN"])
     if duplicates.any():
-        print(
-            f"WARNING: Found {duplicates.sum()} duplicate Protein-Run combinations. "
-            "Taking mean values."
-        )
+        if verbose:
+            print(
+                f"WARNING: Found {duplicates.sum()} duplicate Protein-Run combinations. "
+                "Taking mean values."
+            )
         pivot_data = (
             pivot_data.groupby(["Protein", "originalRUN"])["LogIntensities"].mean().reset_index()
         )
@@ -162,7 +166,10 @@ def prep_msstats_data(
 
 
 def gen_correlation_matrix(
-    data: pd.DataFrame, methods: List[str] = ["pearson", "spearman"], abs_corr: bool = True
+    data: pd.DataFrame,
+    methods: List[str] = ["pearson", "spearman"],
+    abs_corr: bool = True,
+    verbose: bool = True,
 ) -> Dict[str, pd.DataFrame]:
     """
     Generate correlation matrices using multiple correlation methods.
@@ -213,7 +220,8 @@ def gen_correlation_matrix(
     correlations = {}
 
     for method in methods:
-        print(f"Computing {method} correlation matrix...")
+        if verbose:
+            print(f"Computing {method} correlation matrix...")
 
         # Calculate correlation matrix
         corr_matrix = data.corr(method=method)
@@ -241,7 +249,8 @@ def gen_correlation_matrix(
             corr_long.loc[:, "value"] = np.abs(corr_long.loc[:, "value"])
 
         correlations[method] = corr_long
-        print(f"  Generated {len(corr_long)} protein pair correlations")
+        if verbose:
+            print(f"  Generated {len(corr_long)} protein pair correlations")
 
     return correlations
 
@@ -255,6 +264,7 @@ def test_gene_sets(
     comparison: Optional[str] = None,
     fc_pval: Optional[Literal["fc", "pval"]] = None,
     cutoff: Optional[float] = None,
+    verbose: bool = True,
 ) -> pd.DataFrame:
     """
     Test gene sets for significant correlations between member genes.
@@ -341,7 +351,8 @@ def test_gene_sets(
     result_list = []
 
     for pathway_name in pathways:
-        print(f"Processing pathway: {pathway_name}")
+        if verbose:
+            print(f"Processing pathway: {pathway_name}")
 
         current_pathway = gene_sets[pathway_name]
         genes_in_pathway = current_pathway.get("geneSymbols", [])
@@ -593,77 +604,3 @@ def find_sets_with_gene(
                 matching_pathways.append(pathway_name)
 
     return matching_pathways
-
-
-def main() -> None:
-    """
-    Example usage and testing of the gene set analysis functions.
-
-    This function demonstrates a complete gene set analysis workflow using
-    MSstats data and regulatory pathways. It shows data preparation,
-    correlation analysis, and gene set testing with differential analysis.
-    """
-    try:
-        # Load and prepare MSstats data
-        print("Loading MSstats data...")
-        msstats_data = pd.read_csv("data/Talus/processed_data/ProteinLevelData.csv")
-
-        # Filter for specific experimental group
-        msstats_data = msstats_data[msstats_data["GROUP"] == "DMSO"]
-        print(f"Data shape after filtering: {msstats_data.shape}")
-
-        # Prepare data for correlation analysis
-        print("Preparing data for correlation analysis...")
-        prepared_data = prep_msstats_data(msstats_data, gene_map=None, parse_gene=True)
-        prepared_data = prepared_data.reset_index(drop=True)
-        prepared_data.columns.name = None
-        print(f"Prepared data shape: {prepared_data.shape}")
-        print(f"Number of proteins: {prepared_data.shape[1]}")
-
-        # Generate correlation matrices
-        print("Generating correlation matrices...")
-        correlation_data = gen_correlation_matrix(prepared_data, methods=["pearson"], abs_corr=True)
-        print("Correlation matrix generation completed")
-
-        # Load differential analysis results
-        print("Loading differential analysis results...")
-        differential_results = pd.read_csv("data/Talus/processed_data/model.csv")
-        differential_results = parse_protein_name(
-            differential_results, column_name="Protein", parse_gene=True
-        )
-
-        # Test regulatory pathways
-        print("Testing regulatory pathways...")
-        regulatory_results = test_gene_sets(
-            correlation_data,
-            list(prepared_data.columns),
-            "data/gene_sets/regulatory_pathways.json",
-            threshold=0.33,
-            differential_analysis=differential_results,
-            comparison="DMSO-DbET6",
-        )
-
-        # Display results
-        print("\nRegulatory pathway analysis results:")
-        print(regulatory_results)
-
-        # Show top pathways by correlation percentage
-        if len(regulatory_results) > 0:
-            top_pathways = regulatory_results.nlargest(5, "percent")
-            print(f"\nTop 5 pathways by correlation percentage:")
-            for _, row in top_pathways.iterrows():
-                print(
-                    f"  {row['pathway']}: {row['percent']:.3f} "
-                    f"({row['sig_corrs']}/{row['total_tests']} significant)"
-                )
-
-    except FileNotFoundError as e:
-        print(f"Error: Required data file not found - {e}")
-        print("Please ensure all data files are in the correct locations")
-    except Exception as e:
-        print(f"Error during analysis: {e}")
-        print("Please check your data format and file paths")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/data_analysis/pathway_analysis.py
+++ b/src/causomic/data_analysis/pathway_analysis.py
@@ -1,0 +1,941 @@
+"""Pathway over-representation analysis (ORA) and pathway-library utilities.
+
+Fetches gene-set libraries (e.g. via gseapy), runs over-representation analysis,
+and provides tools for selecting a diverse, high-coverage subset of pathways and
+exporting results for visualization.
+"""
+
+import heapq
+import json
+import math
+from pathlib import Path
+from typing import Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+try:
+    import gseapy
+
+    _GSEAPY_AVAILABLE = True
+except ImportError:
+    _GSEAPY_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Pathway data fetching
+# ---------------------------------------------------------------------------
+
+
+def list_pathway_libraries() -> List[str]:
+    """Return available Enrichr gene set library names (requires gseapy)."""
+    _require_gseapy()
+    return gseapy.get_library_name()
+
+
+def fetch_pathway_library(library_name: str = "KEGG_2021_Human") -> Dict[str, List[str]]:
+    """
+    Fetch a gene set library from Enrichr as {pathway: [genes]}.
+
+    Parameters
+    ----------
+    library_name : str
+        Any name returned by ``list_pathway_libraries()``.
+        Common options: "KEGG_2021_Human", "Reactome_2022",
+        "MSigDB_Hallmark_2020", "GO_Biological_Process_2023".
+
+    Returns
+    -------
+    dict mapping pathway name → list of gene symbols
+    """
+    _require_gseapy()
+    return gseapy.get_library(library_name)
+
+
+# ---------------------------------------------------------------------------
+# Membership matrix
+# ---------------------------------------------------------------------------
+
+
+def build_membership_matrix(
+    gene_universe: List[str],
+    pathway_dict: Dict[str, List[str]],
+    min_pathway_size: int = 5,
+    max_pathway_size: int = 500,
+) -> pd.DataFrame:
+    """
+    Build a boolean (G × P) membership matrix.
+
+    Parameters
+    ----------
+    gene_universe : list of gene symbols that form the background universe
+    pathway_dict  : {pathway_name: [gene_symbols]}
+    min_pathway_size, max_pathway_size : filter pathways by how many
+        universe genes they contain
+
+    Returns
+    -------
+    pd.DataFrame of shape (len(gene_universe), n_pathways), dtype bool
+    """
+    universe_set = set(gene_universe)
+    filtered = {
+        name: genes
+        for name, genes in pathway_dict.items()
+        if min_pathway_size <= len(set(genes) & universe_set) <= max_pathway_size
+    }
+    M = pd.DataFrame(False, index=list(gene_universe), columns=list(filtered.keys()))
+    for pathway, genes in filtered.items():
+        members = [g for g in genes if g in universe_set]
+        M.loc[members, pathway] = True
+    return M
+
+
+# ---------------------------------------------------------------------------
+# Over-representation analysis (ORA)
+# ---------------------------------------------------------------------------
+
+
+def run_ora(
+    network_genes: Union[List[str], Set[str], nx.Graph],
+    pathway_dict: Optional[Dict[str, List[str]]] = None,
+    background_genes: Optional[List[str]] = None,
+    library_name: str = "KEGG_2021_Human",
+    min_pathway_size: int = 5,
+    max_pathway_size: int = 500,
+    fdr_method: Literal["bh", "bonferroni"] = "bh",
+) -> pd.DataFrame:
+    """
+    Run over-representation analysis via a one-sided hypergeometric test.
+
+    For each pathway the p-value is P(X ≥ k) where X follows a hypergeometric
+    distribution with parameters::
+
+        N = |background|          (universe size)
+        K = |pathway ∩ background| (pathway size in universe)
+        n = |network ∩ background| (query set size)
+        k = |pathway ∩ network|    (observed overlap)
+
+    Parameters
+    ----------
+    network_genes : genes in the posterior network.
+        Accepts a list/set of gene symbols or a ``networkx.Graph`` whose
+        nodes are gene symbols.
+    pathway_dict : optional pre-loaded {pathway: [genes]} dict.
+        If None, ``library_name`` is fetched from Enrichr via gseapy.
+    background_genes : optional universe of genes to test against.
+        Defaults to the union of all pathway genes and network genes.
+    library_name : Enrichr library used when ``pathway_dict`` is None.
+    min_pathway_size, max_pathway_size : pathway size filters (applied
+        within the background).
+    fdr_method : "bh" (Benjamini–Hochberg) or "bonferroni".
+
+    Returns
+    -------
+    pd.DataFrame sorted by FDR with columns:
+        pathway, overlap, pathway_size, network_size, background_size,
+        p_value, fdr, overlap_genes
+    """
+    # -- resolve network genes -----------------------------------------------
+    if isinstance(network_genes, nx.Graph):
+        network_genes = set(network_genes.nodes())
+    else:
+        network_genes = set(network_genes)
+
+    # -- pathway data ---------------------------------------------------------
+    if pathway_dict is None:
+        pathway_dict = fetch_pathway_library(library_name)
+
+    # -- background -----------------------------------------------------------
+    if background_genes is None:
+        all_pathway_genes: Set[str] = set(g for genes in pathway_dict.values() for g in genes)
+        background_genes = list(all_pathway_genes | network_genes)
+    background_set = set(background_genes)
+
+    # -- membership matrix ---------------------------------------------------
+    M = build_membership_matrix(background_genes, pathway_dict, min_pathway_size, max_pathway_size)
+
+    N = len(background_set)
+    n = len(network_genes & background_set)
+
+    # -- hypergeometric tests ------------------------------------------------
+    records = []
+    for pathway in M.columns:
+        pathway_gene_set = set(M.index[M[pathway]])
+        K = len(pathway_gene_set)
+        overlap_set = pathway_gene_set & network_genes
+        k = len(overlap_set)
+        p_val = stats.hypergeom.sf(k - 1, N, K, n) if k > 0 else 1.0
+        records.append(
+            {
+                "pathway": pathway,
+                "overlap": k,
+                "pathway_size": K,
+                "network_size": n,
+                "background_size": N,
+                "p_value": p_val,
+                "overlap_genes": overlap_set,
+            }
+        )
+
+    df = pd.DataFrame(records)
+    if df.empty:
+        return df
+
+    df["fdr"] = _apply_fdr(df["p_value"].to_numpy(), method=fdr_method)
+    return df.sort_values("fdr").reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Greedy diverse pathway selection (ported from pathway_set.py)
+# ---------------------------------------------------------------------------
+
+
+def compute_jaccard_from_membership(M_bool: np.ndarray) -> np.ndarray:
+    """
+    Compute pairwise Jaccard similarity across pathways.
+
+    Parameters
+    ----------
+    M_bool : (G × P) boolean array
+
+    Returns
+    -------
+    (P × P) Jaccard matrix
+    """
+    M_int = M_bool.astype(int)
+    inter = M_int.T @ M_int
+    sizes = np.diag(inter).astype(float)
+    unions = sizes[:, None] + sizes[None, :] - inter
+    with np.errstate(divide="ignore", invalid="ignore"):
+        J = np.where(unions > 0, inter / unions, 0.0)
+    np.fill_diagonal(J, 1.0)
+    return J
+
+
+def coverage_greedy_select(
+    M: pd.DataFrame,
+    s: pd.Series,
+    w: Optional[pd.Series] = None,
+    K: int = 12,
+    lambda_: float = 0.1,
+    mu: float = 0.3,
+    max_jaccard: Optional[float] = None,
+    precomputed_J: Optional[np.ndarray] = None,
+    seed: Optional[int] = None,
+) -> Dict:
+    """
+    Greedy submodular pathway selection maximising gene coverage while
+    penalising pathway overlap.
+
+    Parameters
+    ----------
+    M : (G × P) DataFrame of bool/0-1 (index=genes, columns=pathways)
+    s : Series (P,) enrichment score per pathway (index = M.columns)
+    w : optional Series (G,) per-gene weights
+    K : number of pathways to select
+    lambda_ : weight for the pathway enrichment score s[p]
+    mu : weight for pairwise Jaccard overlap penalty
+    max_jaccard : hard upper bound on Jaccard similarity with any already-
+        selected pathway (``None`` = no hard constraint)
+    precomputed_J : pre-computed (P × P) Jaccard matrix (optional)
+    seed : if set, shuffle pathways before selection for reproducibility
+
+    Returns
+    -------
+    dict with keys:
+        selected, gains, covered_genes, coverage_curve,
+        unique_genes_added, params, jaccard
+    """
+    M = M.astype(bool).loc[:, s.index]
+    genes = M.index.to_numpy()
+    paths = M.columns.to_numpy()
+    G, P = M.shape
+
+    wv = (
+        np.ones(G, dtype=float)
+        if w is None
+        else w.reindex(M.index).fillna(0.0).to_numpy(dtype=float)
+    )
+
+    Mb = M.to_numpy(dtype=bool)
+
+    if precomputed_J is None:
+        if seed is not None:
+            rng = np.random.default_rng(seed)
+            perm = rng.permutation(P)
+            M = M.iloc[:, perm]
+            s = s.iloc[perm]
+            paths = M.columns.to_numpy()
+            Mb = M.to_numpy(dtype=bool)
+        J = compute_jaccard_from_membership(Mb)
+    else:
+        J = precomputed_J
+        assert J.shape == (P, P)
+
+    sv = s.to_numpy(dtype=float)
+    covered = np.zeros(G, dtype=bool)
+    selected_idx: List[int] = []
+    selected_names: List[str] = []
+    gains: List[float] = []
+    cov_curve: List[float] = []
+    unique_added_list: List[Set[str]] = []
+
+    def marginal_gain(p_idx: int) -> Tuple[float, np.ndarray]:
+        new_genes = Mb[:, p_idx] & (~covered)
+        gain_cov = float(np.dot(wv, new_genes))
+        pen = mu * float(np.sum(J[p_idx, selected_idx])) if selected_idx and mu != 0.0 else 0.0
+        return gain_cov + lambda_ * float(sv[p_idx]) - pen, new_genes
+
+    heap: List[Tuple[float, int, int]] = []
+    stamps = np.zeros(P, dtype=np.int64)
+    for j in range(P):
+        g, _ = marginal_gain(j)
+        heapq.heappush(heap, (-g, j, 0))
+
+    total_cov = 0.0
+    while len(selected_idx) < K and heap:
+        neg_g, j, stamp = heapq.heappop(heap)
+
+        if max_jaccard is not None and selected_idx:
+            if np.any(J[j, selected_idx] > max_jaccard):
+                continue
+
+        g_now, new_mask = marginal_gain(j)
+        if -neg_g != g_now:
+            stamps[j] += 1
+            heapq.heappush(heap, (-g_now, j, stamps[j]))
+            continue
+
+        selected_idx.append(j)
+        selected_names.append(paths[j])
+        gains.append(g_now)
+        newly = new_mask.nonzero()[0]
+        covered[newly] = True
+        unique_added_list.append(set(genes[newly]))
+        total_cov += float(np.dot(wv, new_mask))
+        cov_curve.append(total_cov)
+
+    return {
+        "selected": selected_names,
+        "gains": gains,
+        "covered_genes": set(genes[covered]),
+        "coverage_curve": cov_curve,
+        "unique_genes_added": unique_added_list,
+        "params": {"K": K, "lambda_": lambda_, "mu": mu, "max_jaccard": max_jaccard},
+        "jaccard": J,
+    }
+
+
+def select_diverse_pathways(
+    ora_results: pd.DataFrame,
+    pathway_dict: Dict[str, List[str]],
+    background_genes: List[str],
+    K: int = 12,
+    fdr_threshold: float = 0.05,
+    lambda_: float = 0.1,
+    mu: float = 0.3,
+    max_jaccard: Optional[float] = 0.5,
+    min_pathway_size: int = 5,
+    max_pathway_size: int = 500,
+) -> Dict:
+    """
+    From ORA results, select up to K diverse, non-redundant significant pathways.
+
+    Uses ``coverage_greedy_select`` with ``-log10(fdr)`` as the enrichment
+    score so more significant pathways are preferred, while the Jaccard
+    penalty discourages highly overlapping pathways.
+
+    Parameters
+    ----------
+    ora_results : output of ``run_ora``
+    pathway_dict : {pathway: [genes]} used for the ORA
+    background_genes : universe used in the ORA
+    K : max pathways to return
+    fdr_threshold : pre-filter; only pathways with fdr ≤ this are considered
+    lambda_, mu, max_jaccard : passed to ``coverage_greedy_select``
+
+    Returns
+    -------
+    dict from ``coverage_greedy_select`` (keys: selected, gains, covered_genes, …)
+    """
+    sig = ora_results[ora_results["fdr"] <= fdr_threshold].copy()
+    if sig.empty:
+        return {"selected": [], "gains": [], "covered_genes": set(), "coverage_curve": []}
+
+    sig_pathways = {p: pathway_dict[p] for p in sig["pathway"] if p in pathway_dict}
+    M = build_membership_matrix(background_genes, sig_pathways, min_pathway_size, max_pathway_size)
+    # align ora_results to membership matrix columns
+    sig_aligned = sig.set_index("pathway").reindex(M.columns)
+    # enrichment score: -log10(fdr), clipped to avoid inf
+    fdr_vals = sig_aligned["fdr"].clip(lower=1e-300).to_numpy()
+    scores = pd.Series(-np.log10(fdr_vals), index=M.columns)
+
+    return coverage_greedy_select(M, scores, K=K, lambda_=lambda_, mu=mu, max_jaccard=max_jaccard)
+
+
+# ---------------------------------------------------------------------------
+# Cytoscape export
+# ---------------------------------------------------------------------------
+
+_DILI_COLOR = "#e41a1c"  # overrides pathway color so DILI markers stand out
+# Palette: tab20-derived, with all red-family hues removed so no pathway
+# swatch is confusable with the DILI red above. Substitutes: a teal-green
+# and an olive-green from ColorBrewer Dark2.
+_PATHWAY_PALETTE: Tuple[str, ...] = (
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#1b9e77",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+    "#aec7e8",
+    "#ffbb78",
+    "#98df8a",
+    "#66a61e",
+    "#c5b0d5",
+    "#c49c94",
+    "#f7b6d2",
+    "#c7c7c7",
+    "#dbdb8d",
+    "#9edae5",
+)
+_NO_PATHWAY_COLOR = "#dddddd"  # truly unannotated (not in any pathway)
+_OTHER_PATHWAY_COLOR = "#5e8ca0"  # annotated, but no membership in the top-N
+_DRUG_COLOR = "#222222"
+
+
+def export_to_cytoscape(
+    graph: nx.DiGraph,
+    *,
+    drug_name: str,
+    drug_targets: Iterable[str],
+    dili_markers: Iterable[str],
+    selected_pathways: Dict,
+    pathway_dict: Dict[str, List[str]],
+    ora_results: Optional[pd.DataFrame] = None,
+    path: Union[str, Path] = "network.cyjs",
+) -> Path:
+    """
+    Export a posterior network + pathway annotations for Cytoscape Desktop.
+
+    Writes two files:
+
+    * ``<path>``           — the network as ``.cyjs`` (File → Import → Network
+      from File…). Nodes carry pre-computed positions from a pathway-grouped
+      layout, so the network opens already organized by pathway.
+    * ``<stem>_style.xml`` — a native Cytoscape Vizmap style. Cytoscape Desktop
+      ignores style blocks embedded in ``.cyjs`` imports, so the style ships
+      separately and must be imported once via the Styles panel:
+      ``Styles ▸ ☰ menu ▸ Import Styles from File…``. After import, pick
+      "<drug_name> pathway style" from the Style dropdown.
+
+    Encoding
+    --------
+    * A node is added for ``drug_name`` and connected to each gene in
+      ``drug_targets`` that is present in ``graph`` (dashed edges).
+    * Node shape encodes role:
+
+      - ``drug``         → diamond
+      - ``target``       → triangle (drug target only)
+      - ``dili``         → hexagon  (DILI marker only)
+      - ``target_dili``  → octagon  (both)
+      - ``gene``         → ellipse  (neither)
+
+    * Node fill color encodes the gene's **top pathway** among
+      ``selected_pathways["selected"]``. When a gene belongs to multiple
+      selected pathways, the tie is broken by smallest FDR in ``ora_results``
+      (or smallest pathway size if ``ora_results`` is None). Every pathway
+      membership is also stored on the node as ``pathways`` so Cytoscape's
+      table panel / filters can use it.
+
+    Parameters
+    ----------
+    graph : networkx.DiGraph
+        Posterior network. Node labels should already be gene symbol strings.
+    drug_name : str
+        Label for the drug node (e.g. "clozapine").
+    drug_targets, dili_markers : iterables of gene symbol strings
+    selected_pathways : dict
+        Output of ``select_diverse_pathways``. Only ``selected_pathways["selected"]``
+        is read.
+    pathway_dict : dict
+        Same ``{pathway: [genes]}`` used in the ORA.
+    ora_results : pd.DataFrame, optional
+        Output of ``run_ora``. Used to break ties when a gene is in multiple
+        selected pathways.
+    path : str or Path
+        Output ``.cyjs`` path.
+
+    Returns
+    -------
+    pathlib.Path
+        The path that was written.
+    """
+    out_path = Path(path)
+    selected: List[str] = list(selected_pathways.get("selected", []))
+
+    # Coloring uses (user-selected) ∪ (greedy-coverage extension), capped at
+    # palette size. Just taking top-N by FDR leaves most of the network gray
+    # because the most-significant pathways are usually highly overlapping.
+    # The greedy step picks each next pathway to maximize *new* gene coverage
+    # of the network, so the legend hits coverage saturation fast.
+    palette_size = len(_PATHWAY_PALETTE)
+    network_genes_set = {str(n) for n in graph.nodes()}
+    color_pathways: List[str] = []
+    seen: Set[str] = set()
+    covered: Set[str] = set()
+    for p in selected:
+        if p in pathway_dict and p not in seen:
+            color_pathways.append(p)
+            seen.add(p)
+            covered |= set(pathway_dict[p]) & network_genes_set
+
+    if ora_results is not None and not ora_results.empty and len(color_pathways) < palette_size:
+        sig = ora_results[ora_results["fdr"] <= 0.05]
+        candidates = [p for p in sig["pathway"].tolist() if p in pathway_dict and p not in seen]
+        cand_members = {p: set(pathway_dict[p]) & network_genes_set for p in candidates}
+        while len(color_pathways) < palette_size and candidates:
+            best, best_new = None, 0
+            for p in candidates:
+                new_count = len(cand_members[p] - covered)
+                if new_count > best_new:
+                    best_new = new_count
+                    best = p
+            if best is None or best_new == 0:
+                break
+            color_pathways.append(best)
+            seen.add(best)
+            covered |= cand_members[best]
+            candidates.remove(best)
+
+    color_pathways = color_pathways[:palette_size]
+    color_set = set(color_pathways)
+    pathway_color = {p: _PATHWAY_PALETTE[i % palette_size] for i, p in enumerate(color_pathways)}
+
+    # gene → list of ALL pathway memberships (full pathway_dict),
+    # and separately the subset that drive coloring
+    all_gene_to_pathways: Dict[str, List[str]] = {}
+    sel_gene_to_pathways: Dict[str, List[str]] = {}
+    for p, genes in pathway_dict.items():
+        for g in genes:
+            all_gene_to_pathways.setdefault(g, []).append(p)
+            if p in color_set:
+                sel_gene_to_pathways.setdefault(g, []).append(p)
+
+    # tie-break: smallest FDR (or fallback to smallest pathway)
+    if ora_results is not None and not ora_results.empty:
+        fdr_map = ora_results.set_index("pathway")["fdr"].to_dict()
+
+        def _rank(p: str) -> float:
+            return float(fdr_map.get(p, 1.0))
+
+    else:
+
+        def _rank(p: str) -> float:
+            return float(len(pathway_dict.get(p, [])))
+
+    target_set = {str(g) for g in drug_targets}
+    dili_set = {str(g) for g in dili_markers}
+
+    # ---- pathway-grouped layout ------------------------------------------
+    # Each selected pathway becomes a cluster center placed evenly around a
+    # circle. Genes are assigned to their top_pathway's cluster; genes with no
+    # selected-pathway membership go to an "__other__" cluster placed at the
+    # center. Within each cluster we run a small spring layout on the induced
+    # subgraph so local connectivity is still visible.
+    group_of: Dict[str, str] = {}
+    for n in graph.nodes():
+        name = str(n)
+        sel_pws = sel_gene_to_pathways.get(name, [])
+        top_sel = min(sel_pws, key=_rank) if sel_pws else None
+        group_of[name] = top_sel if top_sel is not None else "__other__"
+
+    groups: Dict[str, List[str]] = {}
+    for name, gname in group_of.items():
+        groups.setdefault(gname, []).append(name)
+
+    # cluster centers: selected pathways on a ring; "__other__" at the origin
+    ring_radius = 1400.0
+    cluster_radius = 320.0
+    ordered_groups = [g for g in selected if g in groups]
+    centers: Dict[str, Tuple[float, float]] = {}
+    n_on_ring = len(ordered_groups)
+    for i, gname in enumerate(ordered_groups):
+        ang = 2.0 * math.pi * i / max(1, n_on_ring)
+        centers[gname] = (ring_radius * math.cos(ang), ring_radius * math.sin(ang))
+    if "__other__" in groups:
+        centers["__other__"] = (0.0, 0.0)
+
+    pos_xy: Dict[str, Tuple[float, float]] = {}
+    for gname, members in groups.items():
+        cx, cy = centers.get(gname, (0.0, 0.0))
+        member_set = set(members)
+        # work on the induced subgraph so the local layout reflects in-cluster edges
+        sub = graph.subgraph([n for n in graph.nodes() if str(n) in member_set])
+        if sub.number_of_nodes() <= 1:
+            for n in members:
+                pos_xy[n] = (cx, cy)
+            continue
+        sub_pos = nx.spring_layout(sub, seed=0, k=1.0 / math.sqrt(len(sub)))
+        # normalize sub-layout to [-1, 1]
+        xs = [p[0] for p in sub_pos.values()]
+        ys = [p[1] for p in sub_pos.values()]
+        xr = (max(xs) - min(xs)) or 1.0
+        yr = (max(ys) - min(ys)) or 1.0
+        for n, (x, y) in sub_pos.items():
+            nx_ = (x - (max(xs) + min(xs)) / 2) / (xr / 2)
+            ny_ = (y - (max(ys) + min(ys)) / 2) / (yr / 2)
+            pos_xy[str(n)] = (cx + nx_ * cluster_radius, cy + ny_ * cluster_radius)
+
+    # drug node: centroid of its in-graph targets (or origin)
+    target_coords = [pos_xy[t] for t in target_set if t in pos_xy]
+    if target_coords:
+        dx = sum(c[0] for c in target_coords) / len(target_coords)
+        dy = sum(c[1] for c in target_coords) / len(target_coords)
+    else:
+        dx, dy = 0.0, 0.0
+
+    def _role(gene: str) -> str:
+        in_t, in_d = gene in target_set, gene in dili_set
+        if in_t and in_d:
+            return "target_dili"
+        if in_t:
+            return "target"
+        if in_d:
+            return "dili"
+        return "gene"
+
+    # -- build nodes ---------------------------------------------------------
+    nodes = []
+    for n in graph.nodes():
+        name = str(n)
+        role = _role(name)
+        all_pws = all_gene_to_pathways.get(name, [])
+        sel_pws = sel_gene_to_pathways.get(name, [])
+        top_sel = min(sel_pws, key=_rank) if sel_pws else None
+        x, y = pos_xy.get(name, (0.0, 0.0))
+        if role in ("dili", "target_dili"):
+            fill = _DILI_COLOR
+        elif top_sel is not None:
+            fill = pathway_color[top_sel]
+        elif all_pws:
+            fill = _OTHER_PATHWAY_COLOR
+        else:
+            fill = _NO_PATHWAY_COLOR
+        nodes.append(
+            {
+                "data": {
+                    "id": name,
+                    "name": name,
+                    "role": role,
+                    "pathways": all_pws,
+                    "n_pathways": len(all_pws),
+                    "selected_pathways": sel_pws,
+                    "top_pathway": top_sel if top_sel is not None else "",
+                    "color": fill,
+                },
+                "position": {"x": x, "y": y},
+            }
+        )
+
+    # drug node
+    nodes.append(
+        {
+            "data": {
+                "id": drug_name,
+                "name": drug_name,
+                "role": "drug",
+                "pathways": [],
+                "n_pathways": 0,
+                "selected_pathways": [],
+                "top_pathway": "",
+                "color": _DRUG_COLOR,
+            },
+            "position": {"x": dx, "y": dy},
+        }
+    )
+
+    # ---- legend nodes -----------------------------------------------------
+    # Vertical strip to the right of the network. One rectangle per
+    # color_pathways entry, plus a title row. A DILI marker row is added at
+    # the bottom when DILI nodes are present so the red override is explained.
+    has_dili_nodes = bool(dili_set & {str(n) for n in graph.nodes()})
+    if color_pathways or has_dili_nodes:
+        legend_x = ring_radius * 2.4
+        legend_top = ring_radius
+        legend_spacing = 80.0
+        nodes.append(
+            {
+                "data": {
+                    "id": "__legend_title__",
+                    "name": "Pathway legend",
+                    "role": "legend_title",
+                    "pathways": [],
+                    "n_pathways": 0,
+                    "selected_pathways": [],
+                    "top_pathway": "",
+                    "color": "#ffffff",
+                },
+                "position": {"x": legend_x, "y": legend_top - legend_spacing},
+            }
+        )
+        for i, pw in enumerate(color_pathways):
+            nodes.append(
+                {
+                    "data": {
+                        "id": f"__legend__{pw}",
+                        "name": pw,
+                        "role": "legend",
+                        "pathways": [pw],
+                        "n_pathways": 1,
+                        "selected_pathways": [pw] if pw in selected else [],
+                        "top_pathway": pw,
+                        "color": pathway_color[pw],
+                    },
+                    "position": {"x": legend_x, "y": legend_top + i * legend_spacing},
+                }
+            )
+        if has_dili_nodes:
+            nodes.append(
+                {
+                    "data": {
+                        "id": "__legend__DILI",
+                        "name": "DILI marker (overrides pathway color)",
+                        "role": "legend",
+                        "pathways": [],
+                        "n_pathways": 0,
+                        "selected_pathways": [],
+                        "top_pathway": "",
+                        "color": _DILI_COLOR,
+                    },
+                    "position": {
+                        "x": legend_x,
+                        "y": legend_top + len(color_pathways) * legend_spacing + legend_spacing,
+                    },
+                }
+            )
+        # "Other pathway" entry — covers genes annotated in pathway_dict but
+        # not in the top-N color pathways
+        has_other_pw_nodes = any(n["data"]["color"] == _OTHER_PATHWAY_COLOR for n in nodes)
+        if has_other_pw_nodes:
+            offset = len(color_pathways) + (2 if has_dili_nodes else 1)
+            nodes.append(
+                {
+                    "data": {
+                        "id": "__legend__OTHER",
+                        "name": "Other pathway (not in top-N)",
+                        "role": "legend",
+                        "pathways": [],
+                        "n_pathways": 0,
+                        "selected_pathways": [],
+                        "top_pathway": "",
+                        "color": _OTHER_PATHWAY_COLOR,
+                    },
+                    "position": {
+                        "x": legend_x,
+                        "y": legend_top + offset * legend_spacing,
+                    },
+                }
+            )
+
+    # -- build edges ---------------------------------------------------------
+    edges = []
+    for i, (u, v, attrs) in enumerate(graph.edges(data=True)):
+        edges.append(
+            {
+                "data": {
+                    "id": f"e{i}",
+                    "source": str(u),
+                    "target": str(v),
+                    "type": "graph",
+                    "interaction": "regulates",
+                    **{k: _jsonable(val) for k, val in attrs.items()},
+                }
+            }
+        )
+
+    graph_node_names = {str(n) for n in graph.nodes()}
+    for j, t in enumerate(target_set):
+        if t in graph_node_names:
+            edges.append(
+                {
+                    "data": {
+                        "id": f"drug_e{j}",
+                        "source": drug_name,
+                        "target": t,
+                        "type": "drug",
+                        "interaction": "targets",
+                    }
+                }
+            )
+
+    cyjs = {
+        "format_version": "1.0",
+        "generated_by": "causomic.data_analysis.export_to_cytoscape",
+        "target_cytoscapejs_version": "~2.1",
+        "directed": True,
+        "multigraph": False,
+        "data": {
+            "name": f"{drug_name} posterior network",
+            "shared_name": f"{drug_name} posterior network",
+            "pathway_colors": pathway_color,
+        },
+        "elements": {"nodes": nodes, "edges": edges},
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(cyjs, f, indent=2)
+
+    # ---- Vizmap XML (separate file) ---------------------------------------
+    # Cytoscape Desktop's .cyjs reader does NOT apply embedded style blocks,
+    # and its "Import Styles from File…" dialog wants the native Vizmap XML
+    # format. We ship the style as <stem>_style.xml. The user imports it once
+    # via: Styles panel ▸ ☰ menu ▸ Import Styles from File… ▸ pick this file.
+    # After importing, select "<drug_name> pathway style" from the Style
+    # dropdown.
+    style_path = out_path.with_name(out_path.stem + "_style.xml")
+    with open(style_path, "w") as f:
+        f.write(_build_vizmap_xml(drug_name))
+
+    return out_path
+
+
+def _build_vizmap_xml(drug_name: str) -> str:
+    """Cytoscape Desktop Vizmap XML. Discrete mappings on ``role`` and ``type``
+    plus a passthrough on the ``color`` column for per-pathway fill."""
+    style_name = f"{drug_name} pathway style"
+    return f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<vizmap documentVersion="3.0">
+  <visualStyle name="{style_name}">
+    <network>
+      <visualProperty default="#FFFFFF" name="NETWORK_BACKGROUND_PAINT"/>
+    </network>
+    <node>
+      <dependency value="false" name="nodeSizeLocked"/>
+      <visualProperty default="ELLIPSE" name="NODE_SHAPE">
+        <discreteMapping attributeName="role" attributeType="string">
+          <discreteMappingEntry attributeValue="drug"         value="DIAMOND"/>
+          <discreteMappingEntry attributeValue="target"       value="TRIANGLE"/>
+          <discreteMappingEntry attributeValue="dili"         value="HEXAGON"/>
+          <discreteMappingEntry attributeValue="target_dili"  value="OCTAGON"/>
+          <discreteMappingEntry attributeValue="legend"       value="ROUND_RECTANGLE"/>
+          <discreteMappingEntry attributeValue="legend_title" value="ROUND_RECTANGLE"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="#DDDDDD" name="NODE_FILL_COLOR">
+        <passthroughMapping attributeName="color" attributeType="string"/>
+      </visualProperty>
+      <visualProperty default="" name="NODE_LABEL">
+        <passthroughMapping attributeName="name" attributeType="string"/>
+      </visualProperty>
+      <visualProperty default="60.0" name="NODE_WIDTH">
+        <discreteMapping attributeName="role" attributeType="string">
+          <discreteMappingEntry attributeValue="drug"         value="200.0"/>
+          <discreteMappingEntry attributeValue="legend"       value="260.0"/>
+          <discreteMappingEntry attributeValue="legend_title" value="260.0"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="60.0" name="NODE_HEIGHT">
+        <discreteMapping attributeName="role" attributeType="string">
+          <discreteMappingEntry attributeValue="drug"         value="200.0"/>
+          <discreteMappingEntry attributeValue="legend"       value="55.0"/>
+          <discreteMappingEntry attributeValue="legend_title" value="55.0"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="#555555" name="NODE_BORDER_PAINT">
+        <discreteMapping attributeName="role" attributeType="string">
+          <discreteMappingEntry attributeValue="legend_title" value="#FFFFFF"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="1.5" name="NODE_BORDER_WIDTH">
+        <discreteMapping attributeName="role" attributeType="string">
+          <discreteMappingEntry attributeValue="legend_title" value="0.0"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="18" name="NODE_LABEL_FONT_SIZE">
+        <discreteMapping attributeName="role" attributeType="string">
+          <discreteMappingEntry attributeValue="drug"         value="28"/>
+          <discreteMappingEntry attributeValue="legend"       value="16"/>
+          <discreteMappingEntry attributeValue="legend_title" value="22"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="#000000" name="NODE_LABEL_COLOR">
+        <discreteMapping attributeName="role" attributeType="string">
+          <discreteMappingEntry attributeValue="drug" value="#FFFFFF"/>
+        </discreteMapping>
+      </visualProperty>
+    </node>
+    <edge>
+      <visualProperty default="DELTA" name="EDGE_TARGET_ARROW_SHAPE"/>
+      <visualProperty default="#999999" name="EDGE_STROKE_UNSELECTED_PAINT">
+        <discreteMapping attributeName="type" attributeType="string">
+          <discreteMappingEntry attributeValue="drug" value="#222222"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="#999999" name="EDGE_TARGET_ARROW_UNSELECTED_PAINT">
+        <discreteMapping attributeName="type" attributeType="string">
+          <discreteMappingEntry attributeValue="drug" value="#222222"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="SOLID" name="EDGE_LINE_TYPE">
+        <discreteMapping attributeName="type" attributeType="string">
+          <discreteMappingEntry attributeValue="drug" value="LONG_DASH"/>
+        </discreteMapping>
+      </visualProperty>
+      <visualProperty default="1.5" name="EDGE_WIDTH">
+        <discreteMapping attributeName="type" attributeType="string">
+          <discreteMappingEntry attributeValue="drug" value="3.0"/>
+        </discreteMapping>
+      </visualProperty>
+    </edge>
+  </visualStyle>
+</vizmap>
+"""
+
+
+def _jsonable(value):
+    """Best-effort coerce edge/node attribute values for JSON."""
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_gseapy() -> None:
+    if not _GSEAPY_AVAILABLE:
+        raise ImportError(
+            "gseapy is required for programmatic pathway fetching. "
+            "Install it with: pip install gseapy"
+        )
+
+
+def _apply_fdr(p_values: np.ndarray, method: str = "bh") -> np.ndarray:
+    """Benjamini-Hochberg or Bonferroni FDR correction (no external deps)."""
+    n = len(p_values)
+    if method == "bonferroni":
+        return np.minimum(p_values * n, 1.0)
+    # Benjamini-Hochberg
+    order = np.argsort(p_values)
+    ranks = np.argsort(order) + 1
+    fdr = np.minimum(1.0, p_values * n / ranks)
+    # enforce monotonicity (step-down): scan from largest rank downward
+    fdr_sorted = fdr[order]
+    fdr_sorted = np.minimum.accumulate(fdr_sorted[::-1])[::-1]
+    result = np.empty(n)
+    result[order] = fdr_sorted
+    return result

--- a/src/causomic/data_analysis/pathway_correlation_analysis.py
+++ b/src/causomic/data_analysis/pathway_correlation_analysis.py
@@ -81,7 +81,10 @@ def parse_protein_name(
 
 
 def prep_msstats_data(
-    data: pd.DataFrame, parse_gene: bool = False, gene_map: Optional[pd.DataFrame] = None
+    data: pd.DataFrame,
+    parse_gene: bool = False,
+    gene_map: Optional[pd.DataFrame] = None,
+    verbose: bool = True,
 ) -> pd.DataFrame:
     """
     Prepare MSstats data for correlation analysis by formatting and reshaping.
@@ -136,10 +139,11 @@ def prep_msstats_data(
     # Check for duplicate entries before pivoting
     duplicates = pivot_data.duplicated(subset=["Protein", "originalRUN"])
     if duplicates.any():
-        print(
-            f"WARNING: Found {duplicates.sum()} duplicate Protein-Run combinations. "
-            "Taking mean values."
-        )
+        if verbose:
+            print(
+                f"WARNING: Found {duplicates.sum()} duplicate Protein-Run combinations. "
+                "Taking mean values."
+            )
         pivot_data = (
             pivot_data.groupby(["Protein", "originalRUN"])["LogIntensities"].mean().reset_index()
         )
@@ -159,7 +163,10 @@ def prep_msstats_data(
 
 
 def gen_correlation_matrix(
-    data: pd.DataFrame, methods: List[str] = ["pearson", "spearman"], abs_corr: bool = True
+    data: pd.DataFrame,
+    methods: List[str] = ["pearson", "spearman"],
+    abs_corr: bool = True,
+    verbose: bool = True,
 ) -> Dict[str, pd.DataFrame]:
     """
     Generate correlation matrices using multiple correlation methods.
@@ -210,7 +217,8 @@ def gen_correlation_matrix(
     correlations = {}
 
     for method in methods:
-        print(f"Computing {method} correlation matrix...")
+        if verbose:
+            print(f"Computing {method} correlation matrix...")
 
         # Calculate correlation matrix
         corr_matrix = data.corr(method=method)
@@ -238,7 +246,8 @@ def gen_correlation_matrix(
             corr_long.loc[:, "value"] = np.abs(corr_long.loc[:, "value"])
 
         correlations[method] = corr_long
-        print(f"  Generated {len(corr_long)} protein pair correlations")
+        if verbose:
+            print(f"  Generated {len(corr_long)} protein pair correlations")
 
     return correlations
 
@@ -252,6 +261,7 @@ def test_gene_sets(
     comparison: Optional[str] = None,
     fc_pval: Optional[Literal["fc", "pval"]] = None,
     cutoff: Optional[float] = None,
+    verbose: bool = True,
 ) -> pd.DataFrame:
     """
     Test gene sets for significant correlations between member genes.
@@ -338,7 +348,8 @@ def test_gene_sets(
     result_list = []
 
     for pathway_name in pathways:
-        print(f"Processing pathway: {pathway_name}")
+        if verbose:
+            print(f"Processing pathway: {pathway_name}")
 
         current_pathway = gene_sets[pathway_name]
         genes_in_pathway = current_pathway.get("geneSymbols", [])
@@ -590,77 +601,3 @@ def find_sets_with_gene(
                 matching_pathways.append(pathway_name)
 
     return matching_pathways
-
-
-def main() -> None:
-    """
-    Example usage and testing of the gene set analysis functions.
-
-    This function demonstrates a complete gene set analysis workflow using
-    MSstats data and regulatory pathways. It shows data preparation,
-    correlation analysis, and gene set testing with differential analysis.
-    """
-    try:
-        # Load and prepare MSstats data
-        print("Loading MSstats data...")
-        msstats_data = pd.read_csv("data/Talus/processed_data/ProteinLevelData.csv")
-
-        # Filter for specific experimental group
-        msstats_data = msstats_data[msstats_data["GROUP"] == "DMSO"]
-        print(f"Data shape after filtering: {msstats_data.shape}")
-
-        # Prepare data for correlation analysis
-        print("Preparing data for correlation analysis...")
-        prepared_data = prep_msstats_data(msstats_data, gene_map=None, parse_gene=True)
-        prepared_data = prepared_data.reset_index(drop=True)
-        prepared_data.columns.name = None
-        print(f"Prepared data shape: {prepared_data.shape}")
-        print(f"Number of proteins: {prepared_data.shape[1]}")
-
-        # Generate correlation matrices
-        print("Generating correlation matrices...")
-        correlation_data = gen_correlation_matrix(prepared_data, methods=["pearson"], abs_corr=True)
-        print("Correlation matrix generation completed")
-
-        # Load differential analysis results
-        print("Loading differential analysis results...")
-        differential_results = pd.read_csv("data/Talus/processed_data/model.csv")
-        differential_results = parse_protein_name(
-            differential_results, column_name="Protein", parse_gene=True
-        )
-
-        # Test regulatory pathways
-        print("Testing regulatory pathways...")
-        regulatory_results = test_gene_sets(
-            correlation_data,
-            list(prepared_data.columns),
-            "data/gene_sets/regulatory_pathways.json",
-            threshold=0.33,
-            differential_analysis=differential_results,
-            comparison="DMSO-DbET6",
-        )
-
-        # Display results
-        print("\nRegulatory pathway analysis results:")
-        print(regulatory_results)
-
-        # Show top pathways by correlation percentage
-        if len(regulatory_results) > 0:
-            top_pathways = regulatory_results.nlargest(5, "percent")
-            print(f"\nTop 5 pathways by correlation percentage:")
-            for _, row in top_pathways.iterrows():
-                print(
-                    f"  {row['pathway']}: {row['percent']:.3f} "
-                    f"({row['sig_corrs']}/{row['total_tests']} significant)"
-                )
-
-    except FileNotFoundError as e:
-        print(f"Error: Required data file not found - {e}")
-        print("Please ensure all data files are in the correct locations")
-    except Exception as e:
-        print(f"Error during analysis: {e}")
-        print("Please check your data format and file paths")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/data_analysis/proteomics_data_processor.py
+++ b/src/causomic/data_analysis/proteomics_data_processor.py
@@ -87,7 +87,7 @@ def format_sim_data(data: pd.DataFrame) -> pd.DataFrame:
     return data
 
 
-def normalize_median(data: pd.DataFrame) -> pd.DataFrame:
+def normalize_median(data: pd.DataFrame, verbose: bool = True) -> pd.DataFrame:
     """
     Apply median-based normalization to intensity data.
 
@@ -140,7 +140,8 @@ def normalize_median(data: pd.DataFrame) -> pd.DataFrame:
     # Remove temporary columns
     data = data.drop(columns=["ABUNDANCE_RUN", "ABUNDANCE_FRACTION"])
 
-    print("INFO: Median-based normalization completed successfully")
+    if verbose:
+        print("INFO: Median-based normalization completed successfully")
 
     return data
 
@@ -234,10 +235,7 @@ def imputation(data: pd.DataFrame) -> pd.DataFrame:
     feature_dummies = pd.get_dummies(keep_data["Feature"], prefix="Feature")
 
     # Combine predictors with target variable
-    model_data = pd.concat(
-        [run_dummies, feature_dummies, keep_data["Intensity"]], 
-        axis=1
-    )
+    model_data = pd.concat([run_dummies, feature_dummies, keep_data["Intensity"]], axis=1)
 
     # Split into training (non-missing) and prediction (missing) sets
     train_mask = model_data["Intensity"].notna()
@@ -572,61 +570,3 @@ def dataProcess(
     summarized_data = summarize_data(processed_data, summarization_method, MBimpute)
 
     return summarized_data
-
-
-def main() -> None:
-    """
-    Example usage and testing of the dataProcess function.
-
-    This function demonstrates how to use the dataProcess pipeline with
-    simulated data from the causomic package. It creates a signaling
-    network, simulates data with missing values, processes it, and visualizes
-    the results.
-    """
-    try:
-        from causomic.simulation.example_graphs import signaling_network
-        from src.causomic.simulation.proteomics_simulator import simulate_data
-    except ImportError as e:
-        print(f"Error importing causomic modules: {e}")
-        print("Please ensure causomic is properly installed")
-        return
-
-    # Generate example signaling network
-    network_data = signaling_network(add_independent_nodes=False)
-
-    # Simulate mass spectrometry data with missing values
-    simulated_data = simulate_data(
-        network_data["Networkx"],
-        coefficients=network_data["Coefficients"],
-        mnar_missing_param=[-5, 0.4],  # Missing not at random parameters
-        add_feature_var=True,
-        n=25,  # Number of replicates
-        seed=3,
-    )
-
-    # Process the simulated feature data
-    processed_data = dataProcess(
-        data=simulated_data["Feature_data"],
-        normalization=False,  # Skip normalization for simulated data
-        summarization_method="TMP",
-        MBimpute=True,
-        sim_data=True,
-    )
-
-    # Visualize results: scatter plot of two proteins
-    if "SOS" in processed_data.columns and "Ras" in processed_data.columns:
-        fig, ax = plt.subplots(figsize=(8, 6))
-        ax.scatter(processed_data["SOS"], processed_data["Ras"], alpha=0.7)
-        ax.set_xlabel("SOS Protein Abundance")
-        ax.set_ylabel("Ras Protein Abundance")
-        ax.set_title("Processed Protein Abundances: SOS vs Ras")
-        ax.grid(True, alpha=0.3)
-        plt.tight_layout()
-        plt.show()
-    else:
-        print("SOS and/or Ras proteins not found in processed data")
-        print(f"Available proteins: {list(processed_data.columns)}")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/graph_construction/__init__.py
+++ b/src/causomic/graph_construction/__init__.py
@@ -1,0 +1,40 @@
+"""Prior-knowledge network construction and reconciliation.
+
+Utilities for building, filtering, and querying biological interaction graphs
+(e.g. from INDRA), and for reconciling a prior network with experimental data
+via bootstrapped structure learning.
+"""
+
+from causomic.graph_construction.prior_data_reconciliation import (
+    calculate_edge_probabilities,
+    prepare_indra_priors,
+    run_bootstrap,
+)
+from causomic.graph_construction.repair import (
+    convert_to_y0_graph,
+    process_failed_test,
+)
+from causomic.graph_construction.utils_nx import (
+    add_evidence_info,
+    filter_graph_by_evidence_count,
+    prepare_graph,
+    query_confounders,
+    query_drug_targets,
+    query_effect_nodes,
+    query_forward_paths,
+)
+
+__all__ = [
+    "add_evidence_info",
+    "calculate_edge_probabilities",
+    "convert_to_y0_graph",
+    "filter_graph_by_evidence_count",
+    "prepare_graph",
+    "prepare_indra_priors",
+    "process_failed_test",
+    "query_confounders",
+    "query_drug_targets",
+    "query_effect_nodes",
+    "query_forward_paths",
+    "run_bootstrap",
+]

--- a/src/causomic/graph_construction/neo4j_indra_queries.py
+++ b/src/causomic/graph_construction/neo4j_indra_queries.py
@@ -210,7 +210,7 @@ def format_query_results(queries: List[Statement]) -> pd.DataFrame:
         "CHEBI": get_chebi_name_from_id,
         "MESH": get_mesh_name,
         "UP": get_gene_name,
-        "GO": get_go_label
+        "GO": get_go_label,
     }
 
     # Custom field mapping for different relation types
@@ -477,30 +477,10 @@ def pull_mesh_data(mesh_ids: List[str], client: Neo4jClient) -> pd.DataFrame:
     data = format_query_results(query_results)
     return data
 
+
 def pull_go_data(go_ids: List[str], client: Neo4jClient) -> pd.DataFrame:
 
     query_ids = [("GO", go_id) for go_id in go_ids]
     query_results = mesh_query(query_ids=query_ids, client=client)
     data = format_query_results(query_results)
     return data
-
-
-def main():
-    from indra_cogex.client import Neo4jClient
-
-    client = Neo4jClient(url=os.getenv("API_URL"), 
-                            auth=(os.getenv("USER"), 
-                                os.getenv("PASSWORD"))
-                        )
-    
-    trog_targets = ['SERPINE1', 'CYP3A4', 'CTNNB1', 'MAPK1']
-
-    dili_targets = ['ALB']
-
-    indra_prior = extract_indra_prior(
-        trog_targets, dili_targets, input_data_graph.columns, client,
-        one_step_evidence=1, two_step_evidence=1,
-        three_step_evidence=3, confounder_evidence=5000000)
-    
-if __name__ == "__main__":
-    main()

--- a/src/causomic/graph_construction/prior_data_reconciliation.py
+++ b/src/causomic/graph_construction/prior_data_reconciliation.py
@@ -532,6 +532,7 @@ class AICGaussIndraPriors(LogLikelihoodGauss):
         #     prior_bonus *= np.log(self.data.shape[0])
         return aic_score + prior_bonus
 
+
 class AICGaussNoPriors(LogLikelihoodGauss):
 
     def __init__(
@@ -559,6 +560,7 @@ class AICGaussNoPriors(LogLikelihoodGauss):
         aic_score = ll - (df_model + 2)
 
         return aic_score
+
 
 class BICGaussIndraPriors(LogLikelihoodGauss):
     """
@@ -716,10 +718,11 @@ class BICGaussNoPriors(LogLikelihoodGauss):
         bic_score = ll - (((df_model + 2) / 2) * np.log(self.data.shape[0]))
 
         return bic_score
-    
+
+
 def random_acyclic_subgraph(nodes, allowed_edges, inclusion_prob=0.15, rng=None, max_indegree=2):
     """Generate a random DAG by greedily adding allowed edges without creating cycles.
-    
+
     Parameters
     ----------
     nodes : list
@@ -752,6 +755,7 @@ def random_acyclic_subgraph(nodes, allowed_edges, inclusion_prob=0.15, rng=None,
             dag.remove_edge(u, v)
 
     return dag
+
 
 def process_bootstrap(
     data: pd.DataFrame,
@@ -837,14 +841,12 @@ def process_bootstrap(
 
     allowed = set(edge_priors.keys())
     est = estimator(data=resampled_data, allowed_additions=allowed)
-    
+
     start_dag = None
     if random_init:
         nodes = list(resampled_data.columns)
-        start_dag = random_acyclic_subgraph(
-                nodes, allowed, 0.15, np.random.default_rng(seed)
-            )
-    
+        start_dag = random_acyclic_subgraph(nodes, allowed, 0.15, np.random.default_rng(seed))
+
     # Estimate the DAG using the custom scoring function
     estimated_dag = est.estimate(
         scoring_method=custom_score,
@@ -856,7 +858,10 @@ def process_bootstrap(
     )
     return estimated_dag
 
-def calculate_edge_probabilities(indra_priors: pd.DataFrame, count_col: str = "evidence_count") -> dict:
+
+def calculate_edge_probabilities(
+    indra_priors: pd.DataFrame, count_col: str = "evidence_count"
+) -> dict:
     """
     Calculate edge probabilities from INDRA evidence counts using power law modeling.
 
@@ -908,7 +913,7 @@ def calculate_edge_probabilities(indra_priors: pd.DataFrame, count_col: str = "e
     CDF transformation ensures that higher evidence counts receive higher
     probabilities while maintaining proper probability interpretation.
     """
-    
+
     edge_evidence = indra_priors[count_col].values.astype(int)
 
     xmin = edge_evidence.min()
@@ -937,9 +942,9 @@ def calculate_edge_probabilities(indra_priors: pd.DataFrame, count_col: str = "e
     return value_to_cdf
 
 
-def prepare_indra_priors(indra_priors: pd.DataFrame,
-                         convert_to_probability: bool,
-                         use_source_counts: bool = False) -> dict:
+def prepare_indra_priors(
+    indra_priors: pd.DataFrame, convert_to_probability: bool, use_source_counts: bool = False
+) -> dict:
     """
     Prepare INDRA prior data for causal discovery by converting to edge probabilities.
 
@@ -1018,7 +1023,7 @@ def prepare_indra_priors(indra_priors: pd.DataFrame,
 
     else:
         indra_priors["edge_p"] = indra_priors[count_col]
-        
+
     edge_probabilities = {
         (
             indra_priors.loc[i, "source"],
@@ -1031,7 +1036,11 @@ def prepare_indra_priors(indra_priors: pd.DataFrame,
 
 
 def remove_high_corr_edges_from_blacklist(
-    data: pd.DataFrame, indra_priors: pd.DataFrame, black_list: set, corr_threshold: float = 0.8
+    data: pd.DataFrame,
+    indra_priors: pd.DataFrame,
+    black_list: set,
+    corr_threshold: float = 0.8,
+    verbose: bool = True,
 ) -> set:
     """
     Remove edges between highly correlated variables from the blacklist.
@@ -1099,7 +1108,8 @@ def remove_high_corr_edges_from_blacklist(
                 high_corr_pairs.add((i, j))
                 high_corr_pairs.add((j, i))  # Both directions
 
-    print(f"High correlation pairs (threshold={corr_threshold}): {len(high_corr_pairs)}")
+    if verbose:
+        print(f"High correlation pairs (threshold={corr_threshold}): {len(high_corr_pairs)}")
 
     # Remove highly correlated edges from blacklist
     updated_blacklist = set(edge for edge in black_list if edge not in high_corr_pairs)
@@ -1126,6 +1136,7 @@ def run_bootstrap(
     convert_to_probability: bool = True,
     use_source_counts: bool = False,
     random_init: bool = False,
+    verbose: bool = True,
 ) -> list:
     """
     Run parallel bootstrap analysis for robust causal discovery with INDRA priors.
@@ -1229,23 +1240,27 @@ def run_bootstrap(
     The choice depends on computational resources and required precision
     for downstream biological interpretation and hypothesis generation.
     """
-    print("INFO: Starting bootstrap causal discovery:")
+    if verbose:
+        print("INFO: Starting bootstrap causal discovery:")
     if add_high_corr_edges_to_priors:
-        print("INFO: Adding high-corr edges to priors:")
+        if verbose:
+            print("INFO: Adding high-corr edges to priors:")
         updated_indra_priors, updated_blacklist = remove_high_corr_edges_from_blacklist(
-            data, indra_priors, expert_knowledge.forbidden_edges, corr_threshold
+            data, indra_priors, expert_knowledge.forbidden_edges, corr_threshold, verbose=verbose
         )
         expert_knowledge.forbidden_edges = updated_blacklist
     else:
         updated_indra_priors = indra_priors
 
-    print("INFO: Calculating edge probabilities.")
+    if verbose:
+        print("INFO: Calculating edge probabilities.")
 
-    edge_probabilities = prepare_indra_priors(updated_indra_priors, 
-                                              convert_to_probability, 
-                                              use_source_counts)
+    edge_probabilities = prepare_indra_priors(
+        updated_indra_priors, convert_to_probability, use_source_counts
+    )
 
-    print("INFO: Running bootstrap.")
+    if verbose:
+        print("INFO: Running bootstrap.")
     bootstrap_dags = Parallel(n_jobs=-2)(
         delayed(process_bootstrap)(
             data,
@@ -1270,30 +1285,3 @@ def run_bootstrap(
     #     )
 
     return bootstrap_dags
-
-
-def main():
-
-    import pickle
-    import time
-
-    # with open("/Users/kohler.d/Library/CloudStorage/OneDrive-NortheasternUniversity/Northeastern/Research/Causal_Inference/AstraZeneca_project/case_studies/compounds/model_input.pkl", "rb") as f:
-    # with open("/mnt/f/OneDrive - Northeastern University/Northeastern/Research/Causal_Inference/AstraZeneca_project/case_studies/compounds/model_input.pkl", "rb") as f:
-    #     model_input = pickle.load(f)
-    
-    # model_input = list(model_input)
-    # model_input[3] = BICGaussIndraPriors
-    # model_input[1].rename(columns={"source_symbol": "source", "target_symbol": "target"}, inplace=True)
-    
-    # model_input.append(False)
-    # model_input = tuple(model_input)
-    # start_time = time.time()
-    # bootstrap_dags = run_bootstrap(*model_input, n_bootstrap=50)
-    # end_time = time.time()
-    # print(f"Time taken: {end_time - start_time} seconds")
-
-
-
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/graph_construction/repair.py
+++ b/src/causomic/graph_construction/repair.py
@@ -1,3 +1,9 @@
+"""Repair posterior DAGs by resolving failed conditional-independence tests.
+
+Converts learned posterior DAGs to y0 graphs and processes failed CI tests to
+propose fixes, such as introducing latent confounders between affected nodes.
+"""
+
 from itertools import combinations
 
 import networkx as nx

--- a/src/causomic/graph_construction/search_path_diagnostic.py
+++ b/src/causomic/graph_construction/search_path_diagnostic.py
@@ -1,3 +1,10 @@
+"""Diagnostics for bootstrap structure-learning stability.
+
+Compares the sets of DAGs recovered from random initializations versus bootstrap
+resampling to assess how sensitive learned structure is to each source of
+variation.
+"""
+
 import networkx as nx
 import numpy as np
 import pandas as pd
@@ -29,11 +36,21 @@ def random_acyclic_subgraph(nodes, allowed_edges, inclusion_prob=0.15, rng=None)
     return dag
 
 
-def run_single_random_init(data, edge_priors, score_fn, estimator,
-                           expert_knowledge, allowed_edges, nodes,
-                           inclusion_prob, max_indegree, seed):
+def run_single_random_init(
+    data,
+    edge_priors,
+    score_fn,
+    estimator,
+    expert_knowledge,
+    allowed_edges,
+    nodes,
+    inclusion_prob,
+    max_indegree,
+    seed,
+):
     """Single Hill Climb run from a random initial DAG on the full dataset."""
     import logging
+
     logging.getLogger("pgmpy").setLevel(logging.WARNING)
 
     rng = np.random.default_rng(seed)
@@ -53,9 +70,16 @@ def run_single_random_init(data, edge_priors, score_fn, estimator,
     return estimated_dag
 
 
-def search_path_diagnostic(data, edge_priors, score_fn, estimator,
-                           expert_knowledge, K=50, inclusion_prob=0.15,
-                           max_indegree=5):
+def search_path_diagnostic(
+    data,
+    edge_priors,
+    score_fn,
+    estimator,
+    expert_knowledge,
+    K=50,
+    inclusion_prob=0.15,
+    max_indegree=5,
+):
     """
     Run K Hill Climb searches from random initializations on the SAME full dataset.
     Compare edge sets to diagnose search path dependence vs genuine signal.
@@ -65,9 +89,16 @@ def search_path_diagnostic(data, edge_priors, score_fn, estimator,
 
     dags = Parallel(n_jobs=-2)(
         delayed(run_single_random_init)(
-            data, edge_priors, score_fn, estimator,
-            expert_knowledge, allowed_edges, nodes,
-            inclusion_prob, max_indegree, seed=i
+            data,
+            edge_priors,
+            score_fn,
+            estimator,
+            expert_knowledge,
+            allowed_edges,
+            nodes,
+            inclusion_prob,
+            max_indegree,
+            seed=i,
         )
         for i in tqdm(range(K), desc="Random init runs")
     )
@@ -81,6 +112,7 @@ def compare_dag_sets(dags_random_init, dags_bootstrap, label_a="random_init", la
     Compare edge stability between two sets of DAGs.
     Returns a DataFrame with per-edge frequencies from each approach.
     """
+
     def edge_frequencies(dags):
         counts = Counter()
         for dag in dags:
@@ -94,12 +126,14 @@ def compare_dag_sets(dags_random_init, dags_bootstrap, label_a="random_init", la
     all_edges = set(freq_a.keys()) | set(freq_b.keys())
     rows = []
     for edge in sorted(all_edges):
-        rows.append({
-            "source": edge[0],
-            "target": edge[1],
-            f"freq_{label_a}": freq_a.get(edge, 0.0),
-            f"freq_{label_b}": freq_b.get(edge, 0.0),
-        })
+        rows.append(
+            {
+                "source": edge[0],
+                "target": edge[1],
+                f"freq_{label_a}": freq_a.get(edge, 0.0),
+                f"freq_{label_b}": freq_b.get(edge, 0.0),
+            }
+        )
 
     df = pd.DataFrame(rows)
     df["abs_diff"] = abs(df[f"freq_{label_a}"] - df[f"freq_{label_b}"])

--- a/src/causomic/graph_construction/utils_neo4j.py
+++ b/src/causomic/graph_construction/utils_neo4j.py
@@ -86,16 +86,18 @@ def get_neighbor_network(
     ... )
     >>> print(f"Found {len(neighbors)} upstream regulators")
     """
-    nodes_str = ", ".join(["'%s'" % norm_id(*node) for node in nodes])  
-            
+    nodes_str = ", ".join(["'%s'" % norm_id(*node) for node in nodes])
+
     # Construct query pattern based on direction requirements
     if upstream and downstream:
         q = "p=(n2:BioEntity)-[r1:indra_rel]->(n1:BioEntity)-[r2:indra_rel]->(n3:BioEntity)"
         relations = f"AND r1.stmt_type IN {relation}" + f" AND r2.stmt_type IN {relation}"
-        evidence_relations = minimum_evidence_helper(
-            minimum_evidence_count, "r1") + " " + minimum_evidence_helper(
-                minimum_evidence_count, "r2")
-    elif upstream and not downstream: 
+        evidence_relations = (
+            minimum_evidence_helper(minimum_evidence_count, "r1")
+            + " "
+            + minimum_evidence_helper(minimum_evidence_count, "r2")
+        )
+    elif upstream and not downstream:
         q = "p=(n2:BioEntity)-[r1:indra_rel]->(n1:BioEntity)"
         relations = f"AND r1.stmt_type IN {relation}"
         evidence_relations = minimum_evidence_helper(minimum_evidence_count, "r1")
@@ -112,7 +114,7 @@ def get_neighbor_network(
         filter = f"AND n2.id IN [{nodes_str}]"
     else:
         filter = ""
-    
+
     query = f"""\
         MATCH {q}
         WHERE

--- a/src/causomic/graph_construction/utils_nx.py
+++ b/src/causomic/graph_construction/utils_nx.py
@@ -51,10 +51,7 @@ def add_evidence_info(graph: nx.DiGraph) -> nx.DiGraph:
         source_keys = len(source_key_union)
 
         # unique statement types across statements
-        stmt_types = list(set(
-            s.get("stmt_type") for s in stmts 
-            if s.get("stmt_type") is not None
-        ))
+        stmt_types = list(set(s.get("stmt_type") for s in stmts if s.get("stmt_type") is not None))
 
         # attach a fresh dict per edge (do not reuse mutable objects)
         new_ev: Dict[str, Any] = {
@@ -92,6 +89,7 @@ def filter_graph_by_evidence_count(graph: nx.DiGraph, evidence_count: int) -> nx
     filtered_graph = graph.edge_subgraph(edges_to_keep).copy()
 
     return filtered_graph
+
 
 def prepare_graph(
     graph: nx.DiGraph,
@@ -134,7 +132,9 @@ def prepare_graph(
         total=graph.number_of_edges(),
         desc="Preparing graph",
     ):
-        if measured_node_set is not None and (u not in measured_node_set or v not in measured_node_set):
+        if measured_node_set is not None and (
+            u not in measured_node_set or v not in measured_node_set
+        ):
             continue
         if allowed_node_types is not None and node_attrs[u].get("ns") not in allowed_node_types:
             continue
@@ -159,7 +159,7 @@ def prepare_graph(
             filtered_statements.append(stmt)
             total_evidence += int(stmt.get("evidence_count") or 0)
             stmt_type_union.add(stmt_type)
-            
+
             curated_flag = stmt.get("curated", False)
             curated_union.add(curated_flag)
 
@@ -295,9 +295,7 @@ def filtered_paths(
         src_thr: Minimum source count per edge (inclusive).
     """
 
-    view = nx.subgraph_view(
-        G, filter_edge=lambda u, v: edge_ok(G, u, v, thr=thr, src_thr=src_thr)
-    )
+    view = nx.subgraph_view(G, filter_edge=lambda u, v: edge_ok(G, u, v, thr=thr, src_thr=src_thr))
     # works for Graph/DiGraph/Multi(Di)Graph (paths are node sequences)
     yield from nx.all_simple_paths(view, source, target, cutoff=cutoff)
 
@@ -317,6 +315,7 @@ def _bfs_all_dists_forward(
     ``excluded`` are not traversed into, so paths cannot route through them.
     """
     from collections import deque
+
     excluded = excluded or set()
     dists: dict = {source: {0}}
     q = deque([(source, 0)])
@@ -352,6 +351,7 @@ def _bfs_all_dists_backward(
     paths cannot route through them.
     """
     from collections import deque
+
     excluded = excluded or set()
     dists: dict = {target: {0}}
     q = deque([(target, 0)])
@@ -371,13 +371,15 @@ def _bfs_all_dists_backward(
                     q.append((u, nd))
     return dists
 
-def query_drug_targets(graph: nx.DiGraph,
-                       drug: str,
-                       target_ev_filter: int = 1,
-                       target_src_filter: int = 1,
-                       target_curated_filter: bool = False,
-                       source_filter: Optional[List[str]] = None) -> pd.DataFrame:
 
+def query_drug_targets(
+    graph: nx.DiGraph,
+    drug: str,
+    target_ev_filter: int = 1,
+    target_src_filter: int = 1,
+    target_curated_filter: bool = False,
+    source_filter: Optional[List[str]] = None,
+) -> pd.DataFrame:
     """
     Query drug targets from a directed graph and return aggregated evidence data.
     This function retrieves all direct targets of a given drug from a NetworkX directed graph,
@@ -438,7 +440,11 @@ def query_drug_targets(graph: nx.DiGraph,
                 if isinstance(sc, dict):
                     all_sources.update(sc.keys())
             src = len(all_sources)
-        if ev >= target_ev_filter and src >= target_src_filter and (not target_curated_filter or curated):
+        if (
+            ev >= target_ev_filter
+            and src >= target_src_filter
+            and (not target_curated_filter or curated)
+        ):
             edges_list.append(
                 (
                     drug,
@@ -448,22 +454,17 @@ def query_drug_targets(graph: nx.DiGraph,
                     curated,
                 )
             )
-    
+
     result_df = pd.DataFrame(
-        edges_list, columns=["source", "target", "evidence_count", 
-                             "source_count", "curated"]
+        edges_list, columns=["source", "target", "evidence_count", "source_count", "curated"]
     )
-    result_df = result_df.groupby(["source", "target", "curated"], 
-                                  as_index=False).agg(
+    result_df = result_df.groupby(["source", "target", "curated"], as_index=False).agg(
         {"evidence_count": "sum", "source_count": "sum"}
     )
     return result_df
 
-def query_effect_nodes(
-    graph: nx.DiGraph,
-    effect: str,
-    target_ev_filter: int = 1) -> pd.DataFrame:
-    
+
+def query_effect_nodes(graph: nx.DiGraph, effect: str, target_ev_filter: int = 1) -> pd.DataFrame:
     """
     Query effect nodes from a directed graph and return aggregated evidence data.
     This function retrieves all direct predecessors of a given effect node from a NetworkX directed graph,
@@ -497,9 +498,7 @@ def query_effect_nodes(
         edge = graph[predecessor][effect]
         statements = edge.get("statements", [])
         ev = sum(stmt.get("evidence_count", 0) for stmt in statements)
-        src = sum(
-            sum(stmt.get("source_counts", {}).values()) for stmt in statements
-        )
+        src = sum(sum(stmt.get("source_counts", {}).values()) for stmt in statements)
         stmt_types = [stmt.get("stmt_type") for stmt in statements if stmt.get("stmt_type")]
 
         if ev >= target_ev_filter:
@@ -517,7 +516,7 @@ def query_effect_nodes(
         }
     )
     return result_df
-    
+
 
 def query_forward_paths(
     graph: nx.DiGraph,
@@ -526,6 +525,7 @@ def query_forward_paths(
     n_mediators: int = 1,
     med_ev_filter: Optional[List[int]] = None,
     med_src_filter: Optional[List[int]] = None,
+    verbose: bool = True,
 ) -> pd.DataFrame:
     """Search for simple forward paths from any start node to any end node.
 
@@ -580,7 +580,8 @@ def query_forward_paths(
 
     for start in tqdm(start_nodes_list, desc="Processing start nodes"):
         if start not in graph.nodes:
-            print(f"Start node '{start}' is missing from graph. Skipping.")
+            if verbose:
+                print(f"Start node '{start}' is missing from graph. Skipping.")
             continue
 
         for end in end_nodes_list:
@@ -591,12 +592,8 @@ def query_forward_paths(
                 thr = med_ev_filter[med]
                 src_thr = med_src_filter[med]
 
-                fwd = _bfs_all_dists_forward(
-                    graph, start, cutoff, thr, src_thr, excluded=excluded
-                )
-                bwd = _bfs_all_dists_backward(
-                    graph, end, cutoff, thr, src_thr, excluded=excluded
-                )
+                fwd = _bfs_all_dists_forward(graph, start, cutoff, thr, src_thr, excluded=excluded)
+                bwd = _bfs_all_dists_backward(graph, end, cutoff, thr, src_thr, excluded=excluded)
 
                 for u, v, edata in graph.edges(data=True):
                     if u == v:
@@ -607,95 +604,16 @@ def query_forward_paths(
                         continue
                     if not edge_ok(graph, u, v, thr, src_thr):
                         continue
-                    if any(
-                        d1 + 1 + d2 == cutoff
-                        for d1 in fwd[u]
-                        for d2 in bwd[v]
-                    ):
+                    if any(d1 + 1 + d2 == cutoff for d1 in fwd[u] for d2 in bwd[v]):
                         seen_edges.add((u, v))
                         ev = edata["evidence"]
                         forward_edge_list.append(
-                            (u, v,
-                             ev["total_evidence"],
-                             ev["source_evidence"],
-                             ev["stmt_type"])
+                            (u, v, ev["total_evidence"], ev["source_evidence"], ev["stmt_type"])
                         )
 
     forward_df = pd.DataFrame(
-        forward_edge_list, columns=["source", "target", "evidence_count", 
-                                    "source_count", "stmt_type"]
+        forward_edge_list,
+        columns=["source", "target", "evidence_count", "source_count", "stmt_type"],
     )
 
     return forward_df
-
-
-def main():
-    from indra.databases import uniprot_client, hgnc_client
-
-    def uniprot_to_hgnc_name(uniprot_mnemonic):
-        """Get an HGNC ID from a UniProt mnemonic."""
-        uniprot_id = uniprot_client.get_id_from_mnemonic(uniprot_mnemonic)
-        if uniprot_id:
-            return uniprot_client.get_gene_name(uniprot_id)
-        else:
-            return None
-    def prepare_data(input_data: pd.DataFrame, drug_name: list[str], missing_threshold: float = 0.5) -> pd.DataFrame:
-        """Prepare input data for graph estimation."""
-        try:
-            input_data = input_data.copy()
-            input_data["Protein"] = input_data["Protein"].apply(uniprot_to_hgnc_name)
-            input_data = input_data.drop_duplicates(subset=["Protein", "SUBJECT"])
-            input_data = input_data.loc[input_data["Protein"].notnull()]
-            # pattern = "|".join(re.escape(d) for d in drug_name)
-
-            # input_data = input_data.loc[
-            #     ~input_data["GROUP"].str.contains(pattern, na=False, case=False, regex=True)
-            # ]
-            input_data = input_data.pivot(index="SUBJECT", columns="Protein", values="LogIntensities")
-            missing_percentage = input_data.isnull().mean()
-            # input_data = input_data.loc[:, missing_percentage[missing_percentage < missing_threshold].index]
-            
-            return input_data
-        
-        except Exception as exc:
-            raise RuntimeError(f"Failed while preparing data for drug '{drug_name}': {exc}") from exc
-        
-    file = '//mnt//c//Users//devon//Downloads//indranet_dir_graph_fix_corr_weights.pkl'
-    import pickle
-
-    import numpy as np
-    _orig_dtype = np.dtype
-    
-    def _patched_dtype(x, *args, **kwargs):
-        # pickle asks for np.dtype("f16"); map it to a real dtype object
-        if x == "f16":
-            try:
-                x = np.longdouble  # prefer the intended meaning
-            except Exception:
-                x = "float64"      # last-resort fallback
-        return _orig_dtype(x, *args, **kwargs)
-
-    np.dtype = _patched_dtype
-    
-    # Replace 'file_path.pkl' with your actual file path
-    with open(file, "rb") as f:
-        graph = pickle.load(f)
-
-    np.dtype = _orig_dtype
-
-    data = pd.read_csv("/mnt/f/OneDrive - Northeastern University/Northeastern/Research/Causal_Inference/MS_causal_inference/benchmarks/data/protein/protein_data.csv")
-    input_data = prepare_data(data, ["troglitazone"])
-    input_names = list(input_data.columns)
-    input_names.append("Chemical and Drug Induced Liver Injury")
-
-    filtered_graph = prepare_graph(graph, input_names, 
-                            ["HGNC", "MESH", "CHEBI"], 
-                            ["gene_disease_association", "Inhibition", 
-                                "DecreaseAmount", "Activation", "IncreaseAmount"])
-    dili_targets = query_effect_nodes(
-        filtered_graph,
-        "Chemical and Drug Induced Liver Injury",
-        target_ev_filter = 1)
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/network.py
+++ b/src/causomic/network.py
@@ -71,6 +71,7 @@ def extract_indra_prior(
     two_step_evidence: int = 1,
     three_step_evidence: int = 3,
     confounder_evidence: int = 10,
+    verbose: bool = True,
 ) -> pd.DataFrame:
     """
     Extract prior biological knowledge from INDRA databases using multi-step pathway queries.
@@ -116,6 +117,10 @@ def extract_indra_prior(
         Minimum evidence count threshold for relationships between confounding variables.
         Higher threshold to focus on well-supported confounding relationships.
         Default is 10.
+
+    verbose : bool, optional
+        If True, print summary statistics of the extracted relationships.
+        Default is True.
 
     Returns
     -------
@@ -231,8 +236,9 @@ def extract_indra_prior(
     prior_network["target"] = prior_network["target"].str.replace("-", "")
 
     # Print summary statistics
-    print(f"Number of proteins pulled: {len(all_network_nodes)}")
-    print(f"Number of reconciled edges pulled: {len(prior_network)}")
+    if verbose:
+        print(f"Number of proteins pulled: {len(all_network_nodes)}")
+        print(f"Number of reconciled edges pulled: {len(prior_network)}")
 
     return prior_network
 
@@ -292,6 +298,7 @@ def estimate_posterior_dag(
     use_source_counts: bool = False,
     return_bootstrap_dags: bool = False,
     random_init: bool = False,
+    verbose: bool = True,
 ) -> NxMixedGraph:
     """
     Estimate a posterior directed acyclic graph (DAG) using bootstrap sampling.
@@ -338,7 +345,7 @@ def estimate_posterior_dag(
         Minimum probability threshold for including edges in the final network.
         Edges appearing in fewer than this fraction of bootstrap samples are
         excluded. Default is 0.5 (50% threshold).
-    
+
     convert_to_probability : bool, optional
         Whether to convert edge counts to probabilities before thresholding. Default is True.
 
@@ -397,7 +404,7 @@ def estimate_posterior_dag(
     """
 
     indra_priors = indra_priors.reset_index(drop=True)
-    
+
     # Extract unique nodes from prior network and clean names
     nodes = pd.unique(indra_priors[["source", "target"]].values.ravel())
     nodes = np.array([node.replace("-", "") for node in nodes])
@@ -450,13 +457,11 @@ def estimate_posterior_dag(
     )
 
     # Run bootstrap sampling to generate multiple DAG hypotheses
-    bootstrap_dags = run_bootstrap(*model_input)
+    bootstrap_dags = run_bootstrap(*model_input, verbose=verbose)
 
     # Integrate bootstrap results into one final DAG using consensus approach
-    posterior_dag = consensus_dag(bootstrap_dags, indra_priors, lam=0.25, 
-                                  min_freq=edge_probability)
-    posterior_dag = pd.DataFrame(posterior_dag.edges, 
-                                 columns=["source", "target"])
+    posterior_dag = consensus_dag(bootstrap_dags, indra_priors, lam=0.25, min_freq=edge_probability)
+    posterior_dag = pd.DataFrame(posterior_dag.edges, columns=["source", "target"])
 
     # Convert posterior DAG to y0 graph format
     y0_graph = convert_to_y0_graph(posterior_dag)
@@ -469,11 +474,14 @@ def estimate_posterior_dag(
         edge_counts.update(list(dag.edges()))
 
     for u, v in y0_graph.directed.edges():
-        y0_graph.directed[u][v]["edge_prob"] = edge_counts[(str(u), str(v))] / total if total > 0 else 0.5
+        y0_graph.directed[u][v]["edge_prob"] = (
+            edge_counts[(str(u), str(v))] / total if total > 0 else 0.5
+        )
 
     if return_bootstrap_dags:
         return y0_graph, bootstrap_dags
     return y0_graph
+
 
 def nodes_on_causal_paths(
     G: NxMixedGraph,
@@ -526,6 +534,7 @@ def repair_confounding(
     max_conditional: int = 2,
     n_jobs: int = -2,
     confounder_evidence: int = 1,
+    verbose: bool = True,
 ) -> NxMixedGraph:
     """
     Check for potential confounders in the estimated posterior DAG and repair if possible.
@@ -584,7 +593,8 @@ def repair_confounding(
 
     # Parallel processing of failed tests
     n = len(failed_tests)
-    print(f"Processing {n} failed tests for confounding repair...")
+    if verbose:
+        print(f"Processing {n} failed tests for confounding repair...")
 
     # Pre-convert rows to dicts to avoid serializing the full DataFrame per worker
     failed_test_rows = [failed_tests.loc[i].to_dict() for i in range(n)]
@@ -639,100 +649,26 @@ def repair_confounding(
                     new_edges_added += 1
 
     # Print summary of confounding repair results
-    print("\n" + "=" * 60)
-    print("CONFOUNDING REPAIR SUMMARY")
-    print("=" * 60)
-    print(f"Total failed tests processed: {total_results}")
-    print(f"Valid results obtained: {valid_results}")
-    print(f"Failed/invalid results: {none_results}")
-    print(f"Successfully repaired confounders: {repaired_count}")
-    print(f"Unrepaired confounders: {unrepaired_count}")
-    if new_nodes_added:
-        print(f"New confounder nodes added: {len(new_nodes_added)}")
-        print(f"Added nodes: {', '.join(sorted(new_nodes_added))}")
-    else:
-        print("No new confounder nodes were added")
-    if new_edges_added > 0:
-        print(f"New edges added to repair confounding: {new_edges_added}")
-    else:
-        print("No new edges were added during confounding repair")
-    repair_rate = (repaired_count / valid_results * 100) if valid_results > 0 else 0
-    print(f"Repair success rate: {repair_rate:.1f}%")
-    print("=" * 60 + "\n")
+    if verbose:
+        repair_rate = (repaired_count / valid_results * 100) if valid_results > 0 else 0
+        print("\n" + "=" * 60)
+        print("CONFOUNDING REPAIR SUMMARY")
+        print("=" * 60)
+        print(f"Total failed tests processed: {total_results}")
+        print(f"Valid results obtained: {valid_results}")
+        print(f"Failed/invalid results: {none_results}")
+        print(f"Successfully repaired confounders: {repaired_count}")
+        print(f"Unrepaired confounders: {unrepaired_count}")
+        if new_nodes_added:
+            print(f"New confounder nodes added: {len(new_nodes_added)}")
+            print(f"Added nodes: {', '.join(sorted(new_nodes_added))}")
+        else:
+            print("No new confounder nodes were added")
+        if new_edges_added > 0:
+            print(f"New edges added to repair confounding: {new_edges_added}")
+        else:
+            print("No new edges were added during confounding repair")
+        print(f"Repair success rate: {repair_rate:.1f}%")
+        print("=" * 60 + "\n")
 
     return repaired_dag
-
-
-def main():
-    from causomic.simulation.proteomics_simulator import simulate_data
-    from causomic.simulation.random_network import generate_structured_dag
-    from causomic.simulation.random_network import generate_indra_data
-    # ── 1. Ground truth DAG ───────────────────────────────────────────────────────
-    gt_dag, roles = generate_structured_dag(
-        n_start=30,
-        n_end=8,
-        max_mediators=4,
-        shared_mediator_prob=0.5,
-        confounder_prob=0.05,
-        seed=17,
-    )
-    n_real_nodes = gt_dag.number_of_nodes()
-    n_real_edges = gt_dag.number_of_edges()
-    n_fake_nodes = n_real_nodes            # ~1× more nodes than real
-    n_fake_edges = n_real_edges * 3        # ~3× more edges than real
-    indra_dag, indra_df, missing_edges = generate_indra_data(
-        gt_dag,
-        num_incorrect_nodes=n_fake_nodes,
-        num_incorrect_edges=n_fake_edges,
-        p_missing_real=0.0,
-    )
-    spurious_nodes = [n for n in indra_dag.nodes() if n not in gt_dag.nodes()]
-
-    augmented_dag = gt_dag.copy()
-    for xn in spurious_nodes:
-        augmented_dag.add_node(xn)   # no edges — fully isolated
-
-    sim = simulate_data(
-        augmented_dag,
-        n=150,
-        add_feature_var=False,   # protein-level only for clarity
-        add_error=True,
-        seed=42,
-    )
-    protein_data = pd.DataFrame(sim['Protein_data'])
-
-    posterior, bootstraps = estimate_posterior_dag(
-        protein_data,
-        indra_priors=indra_df,
-        prior_strength=0.5,
-        scoring_function=BICGaussIndraPriors,
-        search_algorithm=SparseHillClimb,
-        n_bootstrap=100,
-        add_high_corr_edges_to_priors=False,
-        corr_threshold=0.9,
-        edge_probability=0.9,
-        convert_to_probability=True,
-        return_bootstrap_dags=True
-    )
-    # ── Evaluate against ground truth ────────────────────────────────────────────
-    # Build predicted edge set from posterior directed graph
-    pred_edges = set(
-        (str(u), str(v))
-        for u, v in posterior.directed.edges()
-    )
-
-    # Ground truth edge set — all edges including confounders.
-    # Confounders are observed here (included in data and INDRA), so their
-    # edges are valid ground truth to recover.
-    observable_gt_edges = set(gt_dag.edges())
-
-    tp_edges = pred_edges & observable_gt_edges
-    fp_edges = pred_edges - observable_gt_edges
-    fn_edges = observable_gt_edges - pred_edges
-
-    precision = len(tp_edges) / len(pred_edges) if pred_edges else 0.0
-    recall    = len(tp_edges) / len(observable_gt_edges) if observable_gt_edges else 0.0
-    f1        = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
-    
-if __name__ == "__main__":
-    main()

--- a/src/causomic/simulation/__init__.py
+++ b/src/causomic/simulation/__init__.py
@@ -1,4 +1,48 @@
+"""Synthetic graph and data generation for method development and testing.
+
+Provides hand-built example DAGs, procedural random/structured DAG generation
+(including INDRA-style misspecification), cyclic-graph generation, and routines
+to simulate proteomics-style data over a causal graph.
+"""
+
 from causomic.simulation.cyclic_network import (
     generate_cyclic_graph,
     simulate_cyclic_data,
 )
+from causomic.simulation.example_graphs import (
+    backdoor,
+    frontdoor,
+    mediator,
+    signaling_network,
+)
+from causomic.simulation.proteomics_simulator import (
+    add_missing,
+    build_igf_network,
+    generate_coefficients,
+    simulate_data,
+)
+from causomic.simulation.random_network import (
+    generate_indra_data,
+    generate_random_dag,
+    generate_structured_dag,
+    ground_truth_interventional_effect,
+    indra_dag_to_evidence_graph,
+)
+
+__all__ = [
+    "add_missing",
+    "backdoor",
+    "build_igf_network",
+    "frontdoor",
+    "generate_coefficients",
+    "generate_cyclic_graph",
+    "generate_indra_data",
+    "generate_random_dag",
+    "generate_structured_dag",
+    "ground_truth_interventional_effect",
+    "indra_dag_to_evidence_graph",
+    "mediator",
+    "signaling_network",
+    "simulate_cyclic_data",
+    "simulate_data",
+]

--- a/src/causomic/simulation/cyclic_network.py
+++ b/src/causomic/simulation/cyclic_network.py
@@ -180,9 +180,7 @@ def generate_cyclic_graph(
             f"add_cycle_in_start={n_start_cycles} requires n_start >= {n_start_cycles}."
         )
     if n_end_cycles > n_end:
-        raise ValueError(
-            f"add_cycle_in_end={n_end_cycles} requires n_end >= {n_end_cycles}."
-        )
+        raise ValueError(f"add_cycle_in_end={n_end_cycles} requires n_end >= {n_end_cycles}.")
 
     if seed is not None:
         np.random.seed(seed)
@@ -302,8 +300,7 @@ def generate_cyclic_graph(
         node_roles["cycle_nodes"]["end"] = all_cy_nodes
 
     assert not nx.is_directed_acyclic_graph(graph), (
-        "generate_cyclic_graph produced a DAG — cycle injection failed. "
-        "This is a bug."
+        "generate_cyclic_graph produced a DAG — cycle injection failed. " "This is a bug."
     )
 
     return graph, node_roles
@@ -358,10 +355,7 @@ def _simulate_cycle_scc(
     # Initialise every cycle node at its intercept.  Because all n samples share
     # the same starting value, the mean-centred cycle contribution is exactly 0
     # in the first iteration — a clean, unbiased initialisation.
-    current = {
-        node: np.full(n, coefficients[node]["intercept"], dtype=float)
-        for node in members
-    }
+    current = {node: np.full(n, coefficients[node]["intercept"], dtype=float) for node in members}
     frozen = np.zeros(n, dtype=bool)
 
     for _ in range(max_iterations):
@@ -417,6 +411,7 @@ def simulate_cyclic_data(
     include_missing: bool = True,
     mar_missing_param: float = 0.05,
     mnar_missing_param: List[float] = [-3, 0.4],
+    verbose: bool = True,
 ) -> Dict[str, Any]:
     """
     Simulate data from a causal graph that may contain directed cycles.
@@ -493,7 +488,8 @@ def simulate_cyclic_data(
     # Condense graph into a DAG over SCCs for correct processing order.
     condensation = nx.condensation(graph)
 
-    print("simulating cyclic data...")
+    if verbose:
+        print("simulating cyclic data...")
     for scc_idx in nx.topological_sort(condensation):
         members: set = condensation.nodes[scc_idx]["members"]
 
@@ -503,26 +499,20 @@ def simulate_cyclic_data(
                 # Node has no SEM entry (e.g. added by generate_indra_data);
                 # skip so it doesn't block downstream nodes.
                 continue
-            data[node] = simulate_node(
-                data, coefficients[node], n, False, None, node
-            )
+            data[node] = simulate_node(data, coefficients[node], n, False, None, node)
         else:
-            _simulate_cycle_scc(
-                graph, members, data, coefficients, n, threshold, max_iterations
-            )
+            _simulate_cycle_scc(graph, members, data, coefficients, n, threshold, max_iterations)
 
     feature_level_data: Optional[pd.DataFrame] = None
     if add_feature_var:
-        print("adding feature level data...")
-        all_nodes = [
-            node
-            for node in graph.nodes()
-            if node in data and node != "Output"
-        ]
+        if verbose:
+            print("adding feature level data...")
+        all_nodes = [node for node in graph.nodes() if node in data and node != "Output"]
         feature_list = [generate_features(data[node], node) for node in all_nodes]
         feature_level_data = pd.concat(feature_list, ignore_index=True)
 
-        print("masking data...")
+        if verbose:
+            print("masking data...")
         if include_missing:
             feature_level_data = add_missing(
                 feature_level_data, mar_missing_param, mnar_missing_param
@@ -533,6 +523,7 @@ def simulate_cyclic_data(
         "Feature_data": feature_level_data,
         "Coefficients": coefficients,
     }
+
 
 def ground_truth_interventional_effect_cyclic(
     graph: nx.DiGraph,
@@ -591,8 +582,9 @@ def ground_truth_interventional_effect_cyclic(
 
     # Observational baseline: every node's expected value equals its intercept
     # because simulate_node mean-centers parent values.
-    baseline = {node: coefficients[node]["intercept"] for node in graph.nodes()
-                if node in coefficients}
+    baseline = {
+        node: coefficients[node]["intercept"] for node in graph.nodes() if node in coefficients
+    }
 
     # Apply do-operator: cut all incoming edges to intervened nodes.
     modified = graph.copy()
@@ -653,8 +645,9 @@ def ground_truth_interventional_effect_cyclic(
             for node in member_list:
                 delta[node] = delta_vec[idx[node]]
 
-    interventional = {node: baseline[node] + delta.get(node, 0.0)
-                      for node in graph.nodes() if node in baseline}
+    interventional = {
+        node: baseline[node] + delta.get(node, 0.0) for node in graph.nodes() if node in baseline
+    }
     effect = {node: interventional[node] - baseline[node] for node in output_nodes}
 
     return {"baseline": baseline, "interventional": interventional, "effect": effect}

--- a/src/causomic/simulation/example_graphs.py
+++ b/src/causomic/simulation/example_graphs.py
@@ -666,32 +666,3 @@ def signaling_network(
         coef = None
 
     return {"Networkx": graph, "y0": y0_graph, "causomic": causomic_graph, "Coefficients": coef}
-
-
-def main() -> None:
-    med = mediator(n_med=3)
-    bd = backdoor()
-    fd = frontdoor()
-    sn = signaling_network()
-
-    simulated_fd_data = simulate_data(
-        sn["Networkx"],
-        coefficients=sn["Coefficients"],
-        mnar_missing_param=[-5, 0.4],
-        add_feature_var=True,
-        n=50,
-        seed=2,
-    )
-    fd_data = dataProcess(
-        simulated_fd_data["Feature_data"],
-        normalization=False,
-        summarization_method="TMP",
-        MBimpute=False,
-        sim_data=True,
-    )
-    # fd_data = fd_data.dropna(how="all",axis=1)
-    print(fd_data.isna().mean() * 100)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/simulation/proteomics_simulator.py
+++ b/src/causomic/simulation/proteomics_simulator.py
@@ -82,6 +82,7 @@ def simulate_data(
     add_feature_var: bool = True,
     n: int = 1000,
     seed: Optional[int] = None,
+    verbose: bool = True,
 ) -> Dict[str, Any]:
     """
     Simulate realistic proteomics data from causal graph structure.
@@ -203,7 +204,8 @@ def simulate_data(
 
     sorted_nodes = [i for i in nx.topological_sort(graph) if i != "cell_type"]
 
-    print("simulating data...")
+    if verbose:
+        print("simulating data...")
     for node in sorted_nodes:
         node_coefficients = coefficients[node]
         if node in intervention.keys():
@@ -211,8 +213,7 @@ def simulate_data(
         else:
             temp_int = None
 
-        data[node] = simulate_node(data, node_coefficients, 
-                                   n, cell_type, temp_int, node)
+        data[node] = simulate_node(data, node_coefficients, n, cell_type, temp_int, node)
 
     if cell_type:
         data["cell_type"] = np.repeat([i for i in range(n_cells)], n // n_cells)
@@ -229,7 +230,8 @@ def simulate_data(
 
     # break data into features
     if add_feature_var:
-        print("adding feature level data...")
+        if verbose:
+            print("adding feature level data...")
         feature_level_data_list = list()
         for node in sorted_nodes:
             if node != "Output":
@@ -237,7 +239,8 @@ def simulate_data(
 
         feature_level_data = pd.concat(feature_level_data_list, ignore_index=True)
 
-        print("masking data...")
+        if verbose:
+            print("masking data...")
         if include_missing:
             feature_level_data = add_missing(
                 feature_level_data, mar_missing_param, mnar_missing_param
@@ -381,7 +384,7 @@ def simulate_node(
     cell_type: bool,
     intervention: Optional[float],
     node_name: str,
-    ) -> np.ndarray:
+) -> np.ndarray:
     """
     Simulate data for a single node using its structural equation.
 
@@ -569,30 +572,26 @@ def generate_features(data: np.ndarray, node: str) -> pd.DataFrame:
     of causal discovery algorithms under conditions that mirror real
     mass spectrometry proteomics experiments.
     """
-    feature_level_data = pd.DataFrame(columns=["Protein", "Replicate", "Feature", "Intensity"])
-
     number_features = np.random.randint(15, 30)
-    feature_effects = [np.random.uniform(-0.75, 0.75) for _ in range(number_features)]
+    n_samples = len(data)
 
-    for i in range(len(data)):
-        for j in range(number_features):
+    feature_effects = np.random.uniform(-0.75, 0.75, size=number_features)
+    errors = np.random.normal(0, 0.1, size=(n_samples, number_features))
 
-            # Measurement error
-            error = np.random.normal(0, 0.1)
-            feature_level_data = pd.concat(
-                [
-                    feature_level_data,
-                    pd.DataFrame(
-                        {
-                            "Protein": [node],
-                            "Replicate": [i],
-                            "Feature": [j],
-                            "Intensity": [data[i] + feature_effects[j] + error],
-                        }
-                    ),
-                ],
-                ignore_index=True,
-            )
+    # data[:, None] broadcasts (n_samples,) × (number_features,) → (n_samples, number_features)
+    intensities = data[:, None] + feature_effects[None, :] + errors
+
+    replicates = np.repeat(np.arange(n_samples), number_features)
+    features = np.tile(np.arange(number_features), n_samples)
+
+    feature_level_data = pd.DataFrame(
+        {
+            "Protein": node,
+            "Replicate": replicates,
+            "Feature": features,
+            "Intensity": intensities.ravel(),
+        }
+    )
 
     return feature_level_data
 
@@ -927,98 +926,3 @@ def build_igf_network(cell_confounder: bool) -> nx.DiGraph:
         graph.add_edge("cell_type", "Erk")
 
     return graph
-
-
-def main() -> None:
-    """
-    Demonstration script for causomic simulation capabilities.
-
-    Provides example usage of the simulation framework, including data generation,
-    visualization, and basic analysis workflows. This function serves as both
-    a usage tutorial and validation test for the simulation components.
-
-    The demonstration includes:
-    1. Building realistic signaling networks
-    2. Generating simulated proteomics data with hierarchical structure
-    3. Creating diagnostic visualizations
-    4. Showing data preparation for causal analysis
-
-    Examples
-    --------
-    >>> # Run demonstration
-    >>> from causomic.simulation.simulation import main
-    >>> main()  # Will generate plots and print data summaries
-
-    Notes
-    -----
-    This function demonstrates several key workflows:
-
-    1. Network Construction:
-       - Uses predefined signaling network templates
-       - Shows how to specify realistic coefficient structures
-       - Demonstrates network properties and validation
-
-    2. Data Simulation:
-       - Multi-level data generation (protein + feature levels)
-       - Realistic missing data patterns
-       - Biologically motivated noise models
-
-    3. Quality Assessment:
-       - Profile plots for data visualization
-       - Statistical summaries of simulated data
-       - Diagnostic checks for simulation parameters
-
-    4. Workflow Integration:
-       - Preparation for causal discovery algorithms
-       - Data formatting for downstream analysis
-       - Integration with causomic modeling framework
-
-    The function uses predefined coefficient structures that reflect
-    realistic biological relationships in growth factor signaling,
-    making the simulated data suitable for algorithm benchmarking
-    and method development.
-
-    Expected Outputs:
-    - Console output with data summaries and network statistics
-    - Matplotlib plots showing protein expression profiles
-    - Demonstration of data structures and formats
-
-    This main function is particularly useful for:
-    - Learning causomic simulation workflow
-    - Validating installation and dependencies
-    - Understanding data formats and structures
-    - Testing custom network configurations
-    - Benchmarking algorithm performance
-    """
-
-    from causomic.simulation.example_graphs import signaling_network
-    from src.causomic.simulation.proteomics_simulator import simple_profile_plot
-
-    informative_prior_coefs = {
-        "EGF": {"intercept": 6.0, "error": 1},
-        "IGF": {"intercept": 5.0, "error": 1},
-        "SOS": {"intercept": 2, "error": 0.25, "EGF": 0.6, "IGF": 0.6},
-        "Ras": {"intercept": 3, "error": 0.25, "SOS": 0.5},
-        "PI3K": {"intercept": 0, "error": 0.25, "EGF": 0.5, "IGF": 0.5, "Ras": 0.5},
-        "Akt": {"intercept": 1.0, "error": 0.25, "PI3K": 0.75},
-        "Raf": {"intercept": 4, "error": 0.25, "Ras": 1.2, "Akt": -0.4},
-        "Mek": {"intercept": 2.0, "error": 0.25, "Raf": 0.75},
-        "Erk": {"intercept": -2, "error": 0.25, "Mek": 1.0},
-    }
-
-    fd = signaling_network(add_independent_nodes=False)
-    simulated_fd_data = simulate_data(
-        fd["Networkx"],
-        coefficients=informative_prior_coefs,
-        mnar_missing_param=[-3, 0.3],
-        add_feature_var=True,
-        n=25,
-        seed=3,
-    )
-
-    simple_profile_plot(simulated_fd_data["Feature_data"], "Mek")
-    plt.show()
-
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/simulation/random_network.py
+++ b/src/causomic/simulation/random_network.py
@@ -1,3 +1,10 @@
+"""Procedural generation of random and structured causal DAGs.
+
+Generates random/structured ground-truth DAGs, simulates INDRA-style prior
+networks with controllable misspecification, and runs end-to-end graph-recovery
+simulations comparing causomic against baselines (PC, hill-climbing, NOTEARS).
+"""
+
 import networkx as nx
 import numpy as np
 import pandas as pd
@@ -9,7 +16,7 @@ from causomic.simulation.proteomics_simulator import simulate_data
 from causomic.graph_construction.prior_data_reconciliation import (
     BICGaussIndraPriors,
     AICGaussIndraPriors,
-    SparseHillClimb
+    SparseHillClimb,
 )
 from causomic.network import estimate_posterior_dag
 import seaborn as sns
@@ -22,6 +29,7 @@ import os
 import traceback
 import secrets
 import random as _random
+
 
 def generate_random_dag(num_nodes, sparsity_factor):
     """
@@ -40,7 +48,9 @@ def generate_random_dag(num_nodes, sparsity_factor):
         A random DAG.
     """
     dag = nx.DiGraph()
-    node_names = [f"{chr(65 + i)}{i}" for i in range(num_nodes)]  # Generate node names as letters (A, B, C, ...)
+    node_names = [
+        f"{chr(65 + i)}{i}" for i in range(num_nodes)
+    ]  # Generate node names as letters (A, B, C, ...)
     dag.add_nodes_from(node_names)
 
     for i in range(num_nodes):
@@ -215,9 +225,9 @@ def generate_structured_dag(
             dst = end_nodes[int(rng.integers(len(end_nodes)))]
             dag.add_edge(snode, dst)
 
-    assert nx.is_directed_acyclic_graph(dag), (
-        "generate_structured_dag produced a cyclic graph — this is a bug."
-    )
+    assert nx.is_directed_acyclic_graph(
+        dag
+    ), "generate_structured_dag produced a cyclic graph — this is a bug."
 
     node_roles = {
         "start": start_nodes,
@@ -395,7 +405,7 @@ def generate_indra_data(
     # Identify edges that lie on at least one source-to-sink path so that
     # on-path spurious nodes can be inserted between real path nodes.
     sources = [n for n in ground_truth_dag.nodes() if ground_truth_dag.in_degree(n) == 0]
-    sinks   = [n for n in ground_truth_dag.nodes() if ground_truth_dag.out_degree(n) == 0]
+    sinks = [n for n in ground_truth_dag.nodes() if ground_truth_dag.out_degree(n) == 0]
 
     forward_reachable: set = set()
     for s in sources:
@@ -407,7 +417,8 @@ def generate_indra_data(
         backward_reachable.update(nx.descendants(reversed_dag, t) | {t})
 
     path_edges = [
-        (u, v) for u, v in ground_truth_dag.edges()
+        (u, v)
+        for u, v in ground_truth_dag.edges()
         if u in forward_reachable and v in backward_reachable
     ]
 
@@ -439,11 +450,11 @@ def generate_indra_data(
     for _ in range(num_incorrect_edges):
         if preferential_attachment:
             out_deg = np.array([modified_dag.out_degree(n) for n in existing_nodes], dtype=float)
-            in_deg  = np.array([modified_dag.in_degree(n)  for n in existing_nodes], dtype=float)
+            in_deg = np.array([modified_dag.in_degree(n) for n in existing_nodes], dtype=float)
             out_deg += 1.0
-            in_deg  += 1.0
+            in_deg += 1.0
             src = np.random.choice(existing_nodes, p=out_deg / out_deg.sum())
-            dst = np.random.choice(existing_nodes, p=in_deg  / in_deg.sum())
+            dst = np.random.choice(existing_nodes, p=in_deg / in_deg.sum())
         else:
             src = np.random.choice(existing_nodes)
             dst = np.random.choice(existing_nodes)
@@ -475,14 +486,16 @@ def generate_indra_data(
     # Boost edges go only to mediator/spurious nodes to avoid inflating end-node in-degree.
     if start_node_out_mu is not None and start_node_out_mu > 0:
         gt_sources = {n for n in ground_truth_dag.nodes() if ground_truth_dag.in_degree(n) == 0}
-        gt_sinks   = {n for n in ground_truth_dag.nodes() if ground_truth_dag.out_degree(n) == 0}
-        boost_targets = [n for n in modified_dag.nodes()
-                         if n not in gt_sources and n not in gt_sinks]
+        gt_sinks = {n for n in ground_truth_dag.nodes() if ground_truth_dag.out_degree(n) == 0}
+        boost_targets = [
+            n for n in modified_dag.nodes() if n not in gt_sources and n not in gt_sinks
+        ]
         for snode in gt_sources:
             if snode not in modified_dag or not boost_targets:
                 continue
-            target_out = int(np.clip(
-                np.random.lognormal(start_node_out_mu, start_node_out_sigma), 1, 500))
+            target_out = int(
+                np.clip(np.random.lognormal(start_node_out_mu, start_node_out_sigma), 1, 500)
+            )
             n_add = target_out - modified_dag.out_degree(snode)
             if n_add <= 0:
                 continue
@@ -490,19 +503,21 @@ def generate_indra_data(
             if not candidates:
                 continue
             in_degs = np.array([modified_dag.in_degree(n) + 1.0 for n in candidates])
-            chosen  = np.random.choice(
-                len(candidates), size=min(n_add, len(candidates)),
-                replace=False, p=in_degs / in_degs.sum())
+            chosen = np.random.choice(
+                len(candidates),
+                size=min(n_add, len(candidates)),
+                replace=False,
+                p=in_degs / in_degs.sum(),
+            )
             for idx in chosen:
-                modified_dag.add_edge(snode, candidates[idx],
-                                      ground_truth=False)
+                modified_dag.add_edge(snode, candidates[idx], ground_truth=False)
 
     # Guarantee every GT source has ≥1 out-edge and every GT sink has ≥1 in-edge.
     # This can fail when p_missing_real drops all edges from a node.
     gt_sources = {n for n in ground_truth_dag.nodes() if ground_truth_dag.in_degree(n) == 0}
-    gt_sinks   = {n for n in ground_truth_dag.nodes() if ground_truth_dag.out_degree(n) == 0}
+    gt_sinks = {n for n in ground_truth_dag.nodes() if ground_truth_dag.out_degree(n) == 0}
     non_sources = [n for n in modified_dag.nodes() if n not in gt_sources]
-    non_sinks   = [n for n in modified_dag.nodes() if n not in gt_sinks]
+    non_sinks = [n for n in modified_dag.nodes() if n not in gt_sinks]
     for snode in gt_sources:
         if modified_dag.out_degree(snode) == 0 and non_sources:
             target = np.random.choice(non_sources)
@@ -526,20 +541,21 @@ def generate_indra_data(
         modified_dag.edges[u, v]["evidence_count"] = count
 
     edges_data = {
-        'source': [],
-        'target': [],
-        'ground_truth': [],
-        'evidence_count': [],
+        "source": [],
+        "target": [],
+        "ground_truth": [],
+        "evidence_count": [],
     }
     for u, v in modified_dag.edges():
-        edges_data['source'].append(u)
-        edges_data['target'].append(v)
-        edges_data['ground_truth'].append(modified_dag.edges[u, v]["ground_truth"])
-        edges_data['evidence_count'].append(modified_dag.edges[u, v]["evidence_count"])
+        edges_data["source"].append(u)
+        edges_data["target"].append(v)
+        edges_data["ground_truth"].append(modified_dag.edges[u, v]["ground_truth"])
+        edges_data["evidence_count"].append(modified_dag.edges[u, v]["evidence_count"])
 
     edges_df = pd.DataFrame(edges_data)
 
     return modified_dag, edges_df, missing_edges
+
 
 def indra_dag_to_evidence_graph(indra_dag: nx.DiGraph) -> nx.DiGraph:
     """
@@ -575,34 +591,40 @@ def indra_dag_to_evidence_graph(indra_dag: nx.DiGraph) -> nx.DiGraph:
     return g
 
 
-def run_graph_sim():
+def run_graph_sim(verbose: bool = True):
+
+    def _p(*args, **kwargs):
+        if verbose:
+            print(*args, **kwargs)
 
     # grab a CSPRNG seed (32-bit signed range) and apply it to numpy and python's random
     seed = secrets.randbelow(2**31 - 1)
     np.random.seed(seed)
     _random.seed(seed)
 
-    print(f"Using random seed: {seed}")
+    _p(f"Using random seed: {seed}")
 
-    print("Generating random DAG...")
+    _p("Generating random DAG...")
     num_nodes = 10
-    gt_dag = generate_random_dag(num_nodes, .2)
-    
+    gt_dag = generate_random_dag(num_nodes, 0.2)
+
     # pos = nx.spring_layout(gt_dag)
     # nx.draw(gt_dag, pos, with_labels=True, node_color='lightblue', node_size=500, arrowsize=20)
     # plt.title("Random DAG Visualization")
     # plt.show()
-    # print("Generated DAG edges:")
-    # print(gt_dag.edges())
+    # _p("Generated DAG edges:")
+    # _p(gt_dag.edges())
 
-    print("Generating fake INDRA data...")
-    indra_nx, indra_data, _ = generate_indra_data(gt_dag, num_incorrect_nodes=10, num_incorrect_edges=100)
+    _p("Generating fake INDRA data...")
+    indra_nx, indra_data, _ = generate_indra_data(
+        gt_dag, num_incorrect_nodes=10, num_incorrect_edges=100
+    )
     # pos = nx.spring_layout(indra_nx)
     # nx.draw(indra_nx, pos, with_labels=True, node_color='lightblue', node_size=500, arrowsize=20)
     # plt.title("Random DAG Visualization")
     # plt.show()
-    # print("\nINDRa-compatible data:")
-    # print(indra_data)
+    # _p("\nINDRa-compatible data:")
+    # _p(indra_data)
 
     # plt.figure(figsize=(8, 6))
     # sns.kdeplot(
@@ -620,9 +642,8 @@ def run_graph_sim():
     # plt.legend(title="ground_truth")
     # plt.tight_layout()
     # plt.show()
-    
-    
-    print("Simulating proteomics data...")
+
+    _p("Simulating proteomics data...")
     n_obs = 100
     sim_data = simulate_data(
         graph=gt_dag,
@@ -636,117 +657,85 @@ def run_graph_sim():
     all_nodes = list(indra_nx.nodes())
     for i in range(len(all_nodes)):
         if all_nodes[i] not in protein_data.keys():
-            protein_data[all_nodes[i]] = np.random.normal(np.random.uniform(5,20), np.random.uniform(.5,3), size=n_obs)
-    
+            protein_data[all_nodes[i]] = np.random.normal(
+                np.random.uniform(5, 20), np.random.uniform(0.5, 3), size=n_obs
+            )
+
     final_sim_data = pd.DataFrame(protein_data)
 
-    print("Estimating posterior network...")
+    _p("Estimating posterior network...")
     posterior_network = estimate_posterior_dag(
-        final_sim_data, indra_priors=indra_data, 
-        prior_strength=5, 
-        scoring_function=BICGaussIndraPriors, 
-        search_algorithm=SparseHillClimb, 
-        n_bootstrap=200, 
-        add_high_corr_edges_to_priors=False, 
-        corr_threshold=0.9, edge_probability=0.5,
-        convert_to_probability=False
+        final_sim_data,
+        indra_priors=indra_data,
+        prior_strength=5,
+        scoring_function=BICGaussIndraPriors,
+        search_algorithm=SparseHillClimb,
+        n_bootstrap=200,
+        add_high_corr_edges_to_priors=False,
+        corr_threshold=0.9,
+        edge_probability=0.5,
+        convert_to_probability=False,
     )
 
-    print("Evaluating network performance...")
+    _p("Evaluating network performance...")
     result = nx.to_pandas_edgelist(posterior_network.directed)
     result["source"] = result["source"].astype(str)
     result["target"] = result["target"].astype(str)
     result.loc[:, "pred"] = True
-    result = result.merge(indra_data, on=['source', 'target'], how='outer')
+    result = result.merge(indra_data, on=["source", "target"], how="outer")
     result["pred"] = result["pred"].fillna(False)
 
-    print("Recall:", round(recall_score(
-        result["ground_truth"],
-        result["pred"]
-    ), 2))
-    print("Precision:", round(precision_score(
-        result["ground_truth"],
-        result["pred"]
-    ), 2))
-    
-    causomic_recall = recall_score(
-        result["ground_truth"],
-        result["pred"]
-    )
-    causomic_precision = precision_score(
-        result["ground_truth"],
-        result["pred"]
-    )
-    
-    pc_results = fit_pc(final_sim_data)    
-    print("Evaluating PC performance...")
+    _p("Recall:", round(recall_score(result["ground_truth"], result["pred"]), 2))
+    _p("Precision:", round(precision_score(result["ground_truth"], result["pred"]), 2))
+
+    causomic_recall = recall_score(result["ground_truth"], result["pred"])
+    causomic_precision = precision_score(result["ground_truth"], result["pred"])
+
+    pc_results = fit_pc(final_sim_data)
+    _p("Evaluating PC performance...")
     result = nx.to_pandas_edgelist(pc_results[0])
     result["source"] = result["source"].astype(str)
     result["target"] = result["target"].astype(str)
     result.loc[:, "pred"] = True
-    result = result.merge(indra_data, on=['source', 'target'], how='outer')
+    result = result.merge(indra_data, on=["source", "target"], how="outer")
     result["pred"] = result["pred"].fillna(False)
     result["ground_truth"] = result["ground_truth"].fillna(False)
 
-    # print("Accuracy:", round(accuracy_score(
+    # _p("Accuracy:", round(accuracy_score(
     #     result["ground_truth"],
     #     result["pred"]
     # ), 2))
-    print("Recall:", round(recall_score(
-        result["ground_truth"],
-        result["pred"]
-    ), 2))
-    print("Precision:", round(precision_score(
-        result["ground_truth"],
-        result["pred"]
-    ), 2))
-    
-    pc_recall = recall_score(
-        result["ground_truth"],
-        result["pred"]
-    )
-    pc_precision = precision_score(
-        result["ground_truth"],
-        result["pred"]
-    )
-    
+    _p("Recall:", round(recall_score(result["ground_truth"], result["pred"]), 2))
+    _p("Precision:", round(precision_score(result["ground_truth"], result["pred"]), 2))
+
+    pc_recall = recall_score(result["ground_truth"], result["pred"])
+    pc_precision = precision_score(result["ground_truth"], result["pred"])
+
     mmhc_results = fit_hc(final_sim_data)
-    print("Evaluating MMHC performance...")
+    _p("Evaluating MMHC performance...")
     result = nx.to_pandas_edgelist(mmhc_results[0])
     result["source"] = result["source"].astype(str)
     result["target"] = result["target"].astype(str)
     result.loc[:, "pred"] = True
-    result = result.merge(indra_data, on=['source', 'target'], how='outer')
+    result = result.merge(indra_data, on=["source", "target"], how="outer")
     result["pred"] = result["pred"].fillna(False)
     result["ground_truth"] = result["ground_truth"].fillna(False)
 
-    # print("Accuracy:", round(accuracy_score(
+    # _p("Accuracy:", round(accuracy_score(
     #     result["ground_truth"],
     #     result["pred"]
     # ), 2))
-    print("Recall:", round(recall_score(
-        result["ground_truth"],
-        result["pred"]
-    ), 2))
-    print("Precision:", round(precision_score(
-        result["ground_truth"],
-        result["pred"]
-    ), 2))
-    
-    mmhc_recall = recall_score(
-        result["ground_truth"],
-        result["pred"]
-    )
-    mmhc_precision = precision_score(
-        result["ground_truth"],
-        result["pred"]
-    )
-    
+    _p("Recall:", round(recall_score(result["ground_truth"], result["pred"]), 2))
+    _p("Precision:", round(precision_score(result["ground_truth"], result["pred"]), 2))
+
+    mmhc_recall = recall_score(result["ground_truth"], result["pred"])
+    mmhc_precision = precision_score(result["ground_truth"], result["pred"])
+
     # Plot scatterplots for each edge in the ground-truth DAG using final_sim_data
     # edges = [(u, v) for u, v in gt_dag.edges() if u in final_sim_data.columns and v in final_sim_data.columns]
 
     # if len(edges) == 0:
-    #     print("No matching columns in final_sim_data for edges in gt_dag.")
+    #     _p("No matching columns in final_sim_data for edges in gt_dag.")
     # else:
     #     n = len(edges)
     #     ncols = 3
@@ -777,89 +766,35 @@ def run_graph_sim():
 
     #     plt.tight_layout()
     #     plt.show()
-    
+
     notears_results, notears_weights = fit_notears(final_sim_data)
-    
-    print("Evaluating notears performance...")
+
+    _p("Evaluating notears performance...")
     result = nx.to_pandas_edgelist(notears_results)
     result["source"] = result["source"].astype(str)
     result["target"] = result["target"].astype(str)
     result.loc[:, "pred"] = True
-    result = result.merge(indra_data, on=['source', 'target'], how='outer')
+    result = result.merge(indra_data, on=["source", "target"], how="outer")
     result["pred"] = result["pred"].fillna(False)
     result["ground_truth"] = result["ground_truth"].fillna(False)
 
-    # print("Accuracy:", round(accuracy_score(
+    # _p("Accuracy:", round(accuracy_score(
     #     result["ground_truth"],
     #     result["pred"]
     # ), 2))
-    print("Recall:", round(recall_score(
-        result["ground_truth"],
-        result["pred"]
-    ), 2))
-    print("Precision:", round(precision_score(
-        result["ground_truth"],
-        result["pred"]
-    ), 2))
-    
-    notears_recall = recall_score(
-        result["ground_truth"],
-        result["pred"]
+    _p("Recall:", round(recall_score(result["ground_truth"], result["pred"]), 2))
+    _p("Precision:", round(precision_score(result["ground_truth"], result["pred"]), 2))
+
+    notears_recall = recall_score(result["ground_truth"], result["pred"])
+    notears_precision = precision_score(result["ground_truth"], result["pred"])
+
+    return (
+        causomic_recall,
+        causomic_precision,
+        pc_recall,
+        pc_precision,
+        mmhc_recall,
+        mmhc_precision,
+        notears_recall,
+        notears_precision,
     )
-    notears_precision = precision_score(
-        result["ground_truth"],
-        result["pred"]
-    )
-    
-    return causomic_recall, causomic_precision, pc_recall, pc_precision, mmhc_recall, mmhc_precision, notears_recall, notears_precision
-
-    
-if __name__ == "__main__":
-
-    n_runs = 10
-
-    results = []
-    for i in range(n_runs):
-        print(f"Starting run {i+1}/{n_runs}...")
-        t0 = time.time()
-        try:
-            causomic_recall, causomic_precision, pc_recall, pc_precision, mmhc_recall, mmhc_precision, notears_recall, notears_precision = run_graph_sim()
-            success = True
-            error = None
-        except Exception:
-            causomic_recall = causomic_precision = pc_recall = pc_precision = mmhc_recall = mmhc_precision = notears_recall = notears_precision = None
-            success = False
-            error = traceback.format_exc()
-
-        duration = time.time() - t0
-        results.append({
-            "run": i,
-            "causomic_recall": causomic_recall,
-            "causomic_precision": causomic_precision,
-            "pc_recall": pc_recall,
-            "pc_precision": pc_precision,
-            "mmhc_recall": mmhc_recall,
-            "mmhc_precision": mmhc_precision,
-            "notears_recall": notears_recall,
-            "notears_precision": notears_precision,
-            "success": success,
-            "error": error,
-            "duration_s": duration,
-            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-        })
-
-        print(f"Finished run {i+1}/{n_runs} - success={success} - duration={duration:.2f}s")
-
-    df = pd.DataFrame(results)
-
-    out_dir = os.getcwd()
-    csv_path = os.path.join(out_dir, "run_graph_sim_results.csv")
-    pkl_path = os.path.join(out_dir, "run_graph_sim_results.pkl")
-
-    df.to_csv(csv_path, index=False)
-    df.to_pickle(pkl_path)
-
-    print(f"Saved {len(df)} runs to {csv_path} and {pkl_path}")
-    print(df[["causomic_recall", "causomic_precision", "notears_recall", 
-              "notears_precision", "pc_recall", "pc_precision", "mmhc_recall", "mmhc_precision"
-              ]].describe(include="all"))

--- a/src/causomic/validation/__init__.py
+++ b/src/causomic/validation/__init__.py
@@ -1,0 +1,13 @@
+"""Validation and benchmarking utilities.
+
+Tools for comparing learned networks against baselines (PC, hill-climbing,
+NOTEARS) and for running end-to-end benchmark and model-validation workflows.
+"""
+
+from causomic.validation.network_comparison import fit_hc, fit_notears, fit_pc
+
+__all__ = [
+    "fit_hc",
+    "fit_notears",
+    "fit_pc",
+]

--- a/src/causomic/validation/benchmark_workflow.py
+++ b/src/causomic/validation/benchmark_workflow.py
@@ -1,3 +1,10 @@
+"""End-to-end benchmark workflow for validating the LVM pipeline.
+
+Extracts a prior network from INDRA, reconciles it with experimental data,
+fits the latent-variable model, performs interventions, and compares predictions
+against differential-analysis results and simpler baselines.
+"""
+
 # Create a benchmark workflow to validate the LVM implementation
 # - Select drug for testing (troglitazone?)
 # - Define start and end nodes (small network for quick testing)
@@ -54,7 +61,13 @@ def uniprot_to_hgnc_name(uniprot_mnemonic):
 
 
 def reconcile_network(
-    prior_network, data, prior_weight=1, criterion="bic", n_bootstrap=100, edge_probability=0.9
+    prior_network,
+    data,
+    prior_weight=1,
+    criterion="bic",
+    n_bootstrap=100,
+    edge_probability=0.9,
+    verbose=True,
 ):
 
     # Prep data
@@ -66,7 +79,8 @@ def reconcile_network(
             knn_imputer.fit_transform(data), index=data.index, columns=data.columns
         )
     else:
-        print("No missing values in the data.")
+        if verbose:
+            print("No missing values in the data.")
     input_data_imputed.columns = input_data_imputed.columns.str.replace("-", "")
 
     # Define blacklist
@@ -224,7 +238,7 @@ def driz_report(y, yhat, p=1.0, tau=None):
     }
 
 
-def validate_model(model, intervention, target, ground_truth):
+def validate_model(model, intervention, target, ground_truth, verbose=True):
 
     try:
         target = [str(t).replace("-", "") for t in target]
@@ -264,9 +278,11 @@ def validate_model(model, intervention, target, ground_truth):
     save_path = os.path.join(data_folder, fname)
     try:
         comparison_df.to_csv(save_path, index=True)
-        print(f"Saved comparison_df to {save_path}")
+        if verbose:
+            print(f"Saved comparison_df to {save_path}")
     except Exception as e:
-        print(f"Failed to save comparison_df: {e}")
+        if verbose:
+            print(f"Failed to save comparison_df: {e}")
 
     # Reassign aligned series so the existing return call uses the merged data
     gt_values = comparison_df["ground_truth"]
@@ -655,93 +671,3 @@ def parse_args():
     parser.add_argument("--password", type=str, default=None)
     parser.add_argument("--log_file", type=str, default=None)
     return parser.parse_args()
-
-
-def main():
-    args = parse_args()
-    data_folder = os.path.join(os.path.dirname(__file__), "..", "..", "..", "data")
-
-    log_file = args.log_file or os.path.join(
-        data_folder, f"benchmark_log_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
-    )
-    run_benchmark(
-        one_step_evidence=args.one_step_evidence,
-        two_step_evidence=args.two_step_evidence,
-        three_step_evidence=args.three_step_evidence,
-        confounder_evidence=args.confounder_evidence,
-        prior_weight=args.prior_weight,
-        criterion=args.criterion,
-        n_bootstrap=args.n_bootstrap,
-        edge_probability=args.edge_probability,
-        add_high_corr_edges_to_priors=False,
-        api_url=args.api_url,
-        password=args.password,
-        log_file=log_file,
-    )
-
-
-# def main():
-
-#     print("Starting benchmark workflow...")
-#     # Calculated externally
-#     trog_targets = ['SERPINE1', 'CYP3A4', 'CTNNB1', 'MAPK1']
-
-#     dili_targets = ['ABCC2', 'ALB', 'CAT', 'CYP2C19', 'CYP2C9',
-#                      'CYP2E1', 'ENO1', 'GPT', 'GSR', 'GSTM1',
-#                      'GSTT1', 'HLA-A', 'HMOX1', 'HPD', 'KNG1',
-#                      'MTHFR', 'NAT2', 'SOD1']
-
-#     # INDRA client
-#     client = Neo4jClient(
-#         url=os.getenv("API_URL"),
-#         auth=("neo4j", os.getenv("PASSWORD"))
-#     )
-
-#     # Load data & prep for model
-#     data_folder = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data')
-#     input_data_path = os.path.join(data_folder, 'model_input.csv')
-#     input_data = pd.read_csv(input_data_path)
-
-#     # Randomly split input_data into two equal parts
-#     input_data_graph, input_data_scm = train_test_split(
-#         input_data, test_size=0.5, random_state=42)
-
-#     print("Extracting network from INDRA...")
-#     indra_prior = extract_network(
-#         trog_targets, dili_targets, input_data_graph.columns, client,
-#         one_step_evidence=3, two_step_evidence=3,
-#         three_step_evidence=6, confounder_evidence=10)
-
-#     print("Reconciling network with data...")
-#     # Reconcile network with data
-#     posterior_network = reconcile_network(
-#         indra_prior, input_data_graph, prior_weight=1,
-#         criterion='bic', n_bootstrap=100, edge_probability=.9)
-
-#     print("Fitting causal model...")
-#     model = fit_causal_model(posterior_network, input_data_scm)
-
-#     print("Validating model...")
-#     gt_df = pd.read_csv(os.path.join(data_folder, "model.csv"))
-#     gt_df['Protein'] = gt_df['Protein'].apply(lambda x: uniprot_to_hgnc_name(x))
-
-#     # Prepare data for intervention
-#     intervention = gt_df.loc[(gt_df["Protein"].isin(trog_targets)) &
-#                              (gt_df["Label"] == "troglitazone_200 - DMSO_0"),
-#                              ["Protein", "log2FC"]]
-#     intervention = dict(zip(intervention["Protein"], intervention["log2FC"]))
-
-#     outcome = gt_df.loc[(gt_df["Protein"].isin(dili_targets)) &
-#                         (gt_df["Label"] == "troglitazone_200 - DMSO_0"),
-#                         ["Protein", "log2FC"]]
-#     outcome = dict(zip(outcome["Protein"], outcome["log2FC"]))
-
-#     validation_summary = validate_model(model, intervention, dili_targets, outcome)
-
-#     print("Validation summary:")
-#     for k, v in validation_summary.items():
-#         if k != "driz_per_sample":
-#             print(f"{k}: {v}")
-
-if __name__ == "__main__":
-    main()

--- a/src/causomic/validation/network_comparison.py
+++ b/src/causomic/validation/network_comparison.py
@@ -1,3 +1,10 @@
+"""Baseline structure-learning methods for benchmarking.
+
+Wraps standard causal-discovery algorithms -- PC, hill-climbing (HC), and NOTEARS
+-- behind a common interface so their learned networks can be compared against
+causomic-derived networks. NOTEARS support is optional (``causomic[notears]``).
+"""
+
 import pandas as pd
 import numpy as np
 import networkx as nx
@@ -10,6 +17,7 @@ try:
 except ImportError:
     notears_linear = None
 
+
 def _model_to_nx(model) -> nx.DiGraph:
     """Convert a pgmpy DAG/PDAG/BayesianModel to a DiGraph."""
     G = nx.DiGraph()
@@ -18,24 +26,26 @@ def _model_to_nx(model) -> nx.DiGraph:
     G.add_edges_from(list(model.edges()))
     return G
 
+
 def _standardize(X: np.ndarray) -> np.ndarray:
     """Z-score features column-wise (genes)."""
     X = np.asarray(X, dtype=float)
     return StandardScaler(with_mean=True, with_std=True).fit_transform(X)
+
 
 def fit_pc(
     df: pd.DataFrame,
     return_type: str = "pdag",
 ) -> Tuple[nx.DiGraph, object]:
     """
-    PC algorithm (constraint-based).
+    PC algorithm (constraint-based) via pgmpy.
+
     Parameters
     ----------
-    X : array-like, shape (n_samples, n_genes)
-    names : optional list of column (gene) names
-    alpha : significance level for CI tests
-    ci_test : 'pearsonr' (linear) | 'kci' (nonlinear) | 'chisq' (discrete)
-    return_type : 'pdag' (CPDAG) or 'dag' (fully oriented by rules)
+    df : pd.DataFrame
+        Wide-format data with one column per variable (gene).
+    return_type : str, default 'pdag'
+        'pdag' (CPDAG) or 'dag' (fully oriented by Meek's rules).
 
     Returns
     -------
@@ -49,16 +59,14 @@ def fit_pc(
     return G, model
 
 
-def fit_hc(
-    df: pd.DataFrame
-) -> Tuple[nx.DiGraph, object]:
+def fit_hc(df: pd.DataFrame) -> Tuple[nx.DiGraph, object]:
     """
-    Hill Climb Search via pgmpy.
+    Hill-climb structure search via pgmpy (Gaussian BIC score).
+
     Parameters
     ----------
-    score : 'bic' | 'k2'
-    ci_test : 'pearsonr' (continuous) | 'chisq' (discrete) | 'kci'
-    max_indegree : optional integer cap during hill-climb
+    df : pd.DataFrame
+        Wide-format data with one column per variable (gene).
 
     Returns
     -------
@@ -106,17 +114,15 @@ def fit_notears(
 
     p = X.shape[1]
 
-    W = notears_linear(
-        X, lambda1=lambda1, loss_type=loss_type, max_iter=max_iter
-    )
-    
+    W = notears_linear(X, lambda1=lambda1, loss_type=loss_type, max_iter=max_iter)
+
     names = df.columns.tolist()
     G = nx.DiGraph()
     G.add_nodes_from(names)
 
     # NOTEARS: W[i, j] = j -> i
-    for i in range(p):        # child
-        for j in range(p):    # parent
+    for i in range(p):  # child
+        for j in range(p):  # parent
             if i == j:
                 continue
             if abs(W[i, j]) > w_threshold:

--- a/src/causomic/workflows.py
+++ b/src/causomic/workflows.py
@@ -14,11 +14,21 @@ import numpy as np
 import pandas as pd
 from sklearn.model_selection import train_test_split
 
-from causomic.graph_construction.utils_nx import query_effect_nodes, query_forward_paths, query_drug_targets
-from causomic.graph_construction.prior_data_reconciliation import BICGaussIndraPriors, SparseHillClimb
+from causomic.graph_construction.utils_nx import (
+    query_effect_nodes,
+    query_forward_paths,
+    query_drug_targets,
+)
+from causomic.graph_construction.prior_data_reconciliation import (
+    BICGaussIndraPriors,
+    SparseHillClimb,
+)
 from causomic.network import estimate_posterior_dag, repair_confounding
 
-def _graph_counts(graph_like: Any) -> Tuple[Optional[int], Optional[int], Optional[Tuple[int, int]]]:
+
+def _graph_counts(
+    graph_like: Any,
+) -> Tuple[Optional[int], Optional[int], Optional[Tuple[int, int]]]:
     """Return graph node/edge counts for supported graph-like objects."""
     if isinstance(graph_like, pd.DataFrame) and {"source", "target"}.issubset(graph_like.columns):
         node_count = len(pd.unique(graph_like[["source", "target"]].values.ravel()))
@@ -106,14 +116,17 @@ def _log_graph_step(
 
     _append_log_line(line, log_file)
 
-def run_toxicity_detection_workflow(input_data, 
-                                    indra_graph, 
-                                    drug_name,
-                                    drug_target_evidence_count_threshold=2,
-                                    dili_target_evidence_count_threshold=2,
-                                    number_of_mediators=3,
-                                    mediator_evidence_count_threshold=None,
-                                    log_file="graph_step_counts.log"):
+
+def run_toxicity_detection_workflow(
+    input_data,
+    indra_graph,
+    drug_name,
+    drug_target_evidence_count_threshold=2,
+    dili_target_evidence_count_threshold=2,
+    number_of_mediators=3,
+    mediator_evidence_count_threshold=None,
+    log_file="graph_step_counts.log",
+):
     """Run the toxicity workflow and log graph size diagnostics.
 
     Parameters
@@ -137,32 +150,39 @@ def run_toxicity_detection_workflow(input_data,
     """
     if mediator_evidence_count_threshold is None:
         mediator_evidence_count_threshold = [1, 1, 1, 2]
-    
+
     measured_proteins = input_data.columns.tolist()
-    
+
     # Randomly split input_data into two equal parts
     # input_data_graph, _ = train_test_split(input_data, test_size=0.5, random_state=42)
     input_data_graph = input_data.copy()
-    
+
     # Extra drug targets
-    main_drug_targets = query_drug_targets(indra_graph, 
-                       drug_name,
-                       target_ev_filter = drug_target_evidence_count_threshold)
-    main_drug_targets = main_drug_targets.loc[
-        (main_drug_targets["target"].isin(measured_proteins))
-    ].drop_duplicates()["target"].values
-    
+    main_drug_targets = query_drug_targets(
+        indra_graph, drug_name, target_ev_filter=drug_target_evidence_count_threshold
+    )
+    main_drug_targets = (
+        main_drug_targets.loc[(main_drug_targets["target"].isin(measured_proteins))]
+        .drop_duplicates()["target"]
+        .values
+    )
+
     if len(main_drug_targets) == 0:
-        raise ValueError(f"No drug targets found for {drug_name} with evidence count >= {drug_target_evidence_count_threshold}")
+        raise ValueError(
+            f"No drug targets found for {drug_name} with evidence count >= {drug_target_evidence_count_threshold}"
+        )
 
     # Extract DILI nodes
     dili_targets = query_effect_nodes(
         indra_graph,
         "Chemical and Drug Induced Liver Injury",
-        target_ev_filter = dili_target_evidence_count_threshold)
-    dili_targets = dili_targets[
-        (dili_targets["source"].isin(measured_proteins))
-    ].drop_duplicates()["source"].values
+        target_ev_filter=dili_target_evidence_count_threshold,
+    )
+    dili_targets = (
+        dili_targets[(dili_targets["source"].isin(measured_proteins))]
+        .drop_duplicates()["source"]
+        .values
+    )
 
     mapping = {node: node.replace("-", "") for node in indra_graph.nodes()}
     indra_graph = nx.relabel_nodes(indra_graph, mapping)
@@ -171,14 +191,14 @@ def run_toxicity_detection_workflow(input_data,
     _log_workflow_targets(drug_name, main_drug_targets, dili_targets, log_file)
 
     indra_prior = query_forward_paths(
-        graph=indra_graph, 
-        start_nodes=main_drug_targets, 
+        graph=indra_graph,
+        start_nodes=main_drug_targets,
         end_nodes=dili_targets,
         n_mediators=number_of_mediators,
         med_ev_filter=mediator_evidence_count_threshold,
     )
     _log_graph_step("indra_prior", indra_prior, log_file, drug_name=drug_name)
-    
+
     indra_nodes = pd.unique(indra_prior[["source", "target"]].values.ravel())
 
     input_data_graph.columns = input_data_graph.columns.str.replace("-", "")
@@ -190,11 +210,15 @@ def run_toxicity_detection_workflow(input_data,
         input_data_graph,
         indra_prior,
         5,
-        BICGaussIndraPriors, SparseHillClimb,
-        100, False, .5, .5,
+        BICGaussIndraPriors,
+        SparseHillClimb,
+        100,
+        False,
+        0.5,
+        0.5,
     )
     _log_graph_step("posterior_network", posterior_network, log_file, drug_name=drug_name)
-    
+
     repaired_network = repair_confounding(
         input_data_graph,
         posterior_network,
@@ -205,117 +229,3 @@ def run_toxicity_detection_workflow(input_data,
     _log_graph_step("repaired_network", repaired_network, log_file, drug_name=drug_name)
 
     return indra_prior, posterior_network, repaired_network
-
-def main():
-    # Example usage
-    input_data_path = '~/OneDrive - Northeastern University/Northeastern/Research/Causal_Inference/AstraZeneca_project/data/Protein/ProteinLevelData_NoNormalization.csv'
-    rna_df = pd.read_csv("~/OneDrive - Northeastern University/Northeastern/Research/Causal_Inference/AstraZeneca_project/data/RNAseq/RNAseq_model_input.csv")
-    input_data = pd.read_csv(input_data_path)
-    
-    input_data['Drug'] = input_data['GROUP'].str.split('_').str[0]
-    
-    protein_drugs = ['clozapine', 'dasatinib', 'doxorubicin', 'idarubicin hcl',
-                     'lapatinib', 'sunitinib', 'troglitazone', 'ketoconazole']
-    rna_drugs = ['tolcapone', 'clozapine', 'Ketoconazole', 'dasatinib',
-                 'doxorubicin', 'idarubicin hcl', 'sunitinib', 'ethacrynic acid',
-                 'rosiglitazone', 'clopidogrel', 'sorafenib tosylate', 'ticrynafen',
-                 'cyclofenil', 'carboxyamidotriazole', 'bosentan', 'alpidem',
-                 'clomiphene', 'aripiprazole', 'ibufenac', 'erlotinib',
-                 'olanzapine', 'mitoxantrone dihcl', 'pioglitazone', 'ambrisentan',
-                 'regorafenib', 'lapatinib', 'troglitazone', 'ticlopidine',
-                 'ketoconazole']
-    
-    drug_name = ['tolcapone']
-    
-    input_data = prepare_data(input_data, drug_name[0])
-    
-    import numpy as np
-    _orig_dtype = np.dtype
-    
-    def _patched_dtype(x, *args, **kwargs):
-        # pickle asks for np.dtype("f16"); map it to a real dtype object
-        if x == "f16":
-            try:
-                x = np.longdouble  # prefer the intended meaning
-            except Exception:
-                x = "float64"      # last-resort fallback
-        return _orig_dtype(x, *args, **kwargs)
-
-    np.dtype = _patched_dtype
-
-    local_indra_path = '/mnt/f/OneDrive - Northeastern University/Northeastern/Research/Causal_Inference/AstraZeneca_project/data/INDRA/indranet_hgnc.pkl'
-    with open(local_indra_path, 'rb') as f:
-        graph = pickle.load(f)
-        
-    np.dtype = _orig_dtype
-    
-    prior_network, posterior_network, repaired_network = run_toxicity_detection_workflow(
-        input_data, graph, drug_name, drug_target_evidence_count_threshold=1,
-        mediator_evidence_count_threshold=[1,4,4,8])
-    print(prior_network)
-    
-    # import matplotlib.pyplot as plt
-
-    # # Convert edge list to NetworkX graph if needed
-    # if isinstance(prior_network, pd.DataFrame):
-    #     G = nx.DiGraph()
-    #     for _, row in prior_network.iterrows():
-    #         G.add_edge(row['source'], row['target'])
-    # else:
-    #     G = prior_network
-
-    # # Create visualization
-    # plt.figure(figsize=(14, 10))
-    # pos = nx.spring_layout(G, k=2, iterations=50)
-    # nx.draw_networkx_nodes(G, pos, node_color='lightblue', node_size=500)
-    # nx.draw_networkx_edges(G, pos, edge_color='gray', arrows=True, arrowsize=20)
-    # nx.draw_networkx_labels(G, pos, font_size=8)
-    # plt.title("Prior Network Visualization")
-    # plt.axis('off')
-    # plt.tight_layout()
-    # plt.show()
-
-    # # Convert posterior network directed graph to NetworkX if needed
-    # if hasattr(posterior_network, 'directed'):
-    #     G_posterior = posterior_network.directed
-    # else:
-    #     G_posterior = posterior_network
-
-    # # Create visualization for posterior network
-    # plt.figure(figsize=(14, 10))
-    # pos_posterior = nx.spring_layout(G_posterior, k=2, iterations=50)
-    # nx.draw_networkx_nodes(G_posterior, pos_posterior, node_color='lightgreen', node_size=500)
-    # nx.draw_networkx_edges(G_posterior, pos_posterior, edge_color='gray', arrows=True, arrowsize=20)
-    # nx.draw_networkx_labels(G_posterior, pos_posterior, font_size=8)
-    # plt.title("Posterior Network Visualization")
-    # plt.axis('off')
-    # plt.tight_layout()
-    # plt.show()
-
-    # # Convert repaired network directed graph to NetworkX if needed
-    # if hasattr(repaired_network, 'directed'):
-    #     G_repaired = repaired_network.directed.copy()
-    # if hasattr(repaired_network, 'undirected'):
-    #     for edge in repaired_network.undirected.edges():
-    #         G_repaired.add_edge(edge[0], edge[1], style='dashed')
-    #         G_repaired.add_edge(edge[1], edge[0], style='dashed')
-
-
-    # # Create visualization for repaired network
-    # plt.figure(figsize=(14, 10))
-    # pos_repaired = nx.spring_layout(G_repaired, k=2, iterations=50)
-    # # Draw directed edges
-    # directed_edges = [(u, v) for u, v, d in G_repaired.edges(data=True) if d.get('style') != 'dashed']
-    # undirected_edges = [(u, v) for u, v, d in G_repaired.edges(data=True) if d.get('style') == 'dashed']
-    # nx.draw_networkx_edges(G_repaired, pos_repaired, edgelist=directed_edges, edge_color='gray', arrows=True, arrowsize=20)
-    # nx.draw_networkx_edges(G_repaired, pos_repaired, edgelist=undirected_edges, edge_color='blue', style='dashed', arrows=False, width=2)
-    # nx.draw_networkx_nodes(G_repaired, pos_repaired, node_color='lightcoral', node_size=500)
-    # nx.draw_networkx_edges(G_repaired, pos_repaired, edge_color='gray', arrows=True, arrowsize=20)
-    # nx.draw_networkx_labels(G_repaired, pos_repaired, font_size=8)
-    # plt.title("Repaired Network Visualization")
-    # plt.axis('off')
-    # plt.tight_layout()
-    # plt.show()
-
-if __name__ == "__main__":
-    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
+import importlib
 import os
 import sys
-import importlib
 
 # Ensure src/ is on sys.path so imports work during collection
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_cyclic_network.py
+++ b/tests/test_cyclic_network.py
@@ -1,0 +1,253 @@
+"""Tests for cyclic-graph generation and data simulation.
+
+`generate_cyclic_graph` builds a structured graph that may contain feedback
+cycles; `simulate_cyclic_data` runs a fixed-point simulation over such a graph
+to produce protein- and feature-level data.
+"""
+
+import importlib
+
+import networkx as nx
+import numpy as np
+import pytest
+
+cn = importlib.import_module("causomic.simulation.cyclic_network")
+
+
+def test_generate_cyclic_graph_roles():
+    graph, roles = cn.generate_cyclic_graph(seed=3, add_cycle_in_mediators=1)
+    assert isinstance(graph, nx.DiGraph)
+    assert {"start", "end", "mediators", "confounders", "cycle_nodes"}.issubset(roles)
+
+
+def test_generate_cyclic_graph_requires_a_cycle_location():
+    with pytest.raises(ValueError):
+        cn.generate_cyclic_graph(seed=3)
+
+
+def test_generate_cyclic_graph_can_introduce_cycle():
+    graph, _ = cn.generate_cyclic_graph(seed=3, add_cycle_in_mediators=1, cycle_size=2)
+    assert not nx.is_directed_acyclic_graph(graph)
+
+
+def test_generate_cyclic_graph_is_reproducible():
+    g_a, _ = cn.generate_cyclic_graph(seed=7, add_cycle_in_mediators=1)
+    g_b, _ = cn.generate_cyclic_graph(seed=7, add_cycle_in_mediators=1)
+    assert set(g_a.edges()) == set(g_b.edges())
+
+
+def test_simulate_cyclic_data_structure():
+    graph, roles = cn.generate_cyclic_graph(seed=3, add_cycle_in_mediators=1, cycle_size=2)
+    out = cn.simulate_cyclic_data(graph, roles, n=40, seed=3, verbose=False)
+    assert set(out) == {"Protein_data", "Feature_data", "Coefficients"}
+    # Every graph node should have simulated protein-level values.
+    assert set(out["Protein_data"]) == set(graph.nodes())
+    for node in graph.nodes():
+        assert np.asarray(out["Protein_data"][node]).shape == (40,)
+
+
+def test_simulate_cyclic_data_is_reproducible():
+    graph, roles = cn.generate_cyclic_graph(seed=5, add_cycle_in_mediators=1)
+    a = cn.simulate_cyclic_data(graph, roles, n=30, seed=9, verbose=False)
+    b = cn.simulate_cyclic_data(graph, roles, n=30, seed=9, verbose=False)
+    for node in graph.nodes():
+        assert np.allclose(a["Protein_data"][node], b["Protein_data"][node])
+
+
+def test_simulate_cyclic_data_without_feature_variation():
+    graph, roles = cn.generate_cyclic_graph(seed=5, add_cycle_in_mediators=1)
+    out = cn.simulate_cyclic_data(graph, roles, n=20, seed=1, add_feature_var=False, verbose=False)
+    assert out["Feature_data"] is None
+
+
+# --------------------------------------------------------------------------- #
+# generate_cyclic_graph: start-node cycles (lines 205-236)
+# --------------------------------------------------------------------------- #
+def test_start_cycle_through_existing_mediator_size_two():
+    # mediator_cycle_prob=1.0 forces every start cycle to route through an
+    # existing mediator; cycle_size=2 hits the two-node anchor<->mediator loop.
+    graph, roles = cn.generate_cyclic_graph(
+        seed=11,
+        add_cycle_in_start=1,
+        cycle_size=2,
+        mediator_cycle_prob=1.0,
+    )
+    assert not nx.is_directed_acyclic_graph(graph)
+    assert "start" in roles["cycle_nodes"]
+    anchor = roles["start"][0]
+    # Anchor participates in a mutual edge with the routed mediator.
+    assert any(graph.has_edge(anchor, m) and graph.has_edge(m, anchor) for m in graph.successors(anchor))
+
+
+def test_start_cycle_through_existing_mediator_size_three():
+    # cycle_size=3 with mediator routing exercises the fresh-node chain branch.
+    graph, roles = cn.generate_cyclic_graph(
+        seed=13,
+        add_cycle_in_start=1,
+        cycle_size=3,
+        mediator_cycle_prob=1.0,
+    )
+    assert not nx.is_directed_acyclic_graph(graph)
+    cy = roles["cycle_nodes"]["start"]
+    assert any(name.startswith("CYS0_") for name in cy)
+
+
+def test_start_cycle_all_fresh_nodes():
+    # mediator_cycle_prob=0.0 forces the all-fresh-node bridge branch.
+    graph, roles = cn.generate_cyclic_graph(
+        seed=17,
+        add_cycle_in_start=2,
+        n_start=3,
+        cycle_size=3,
+        mediator_cycle_prob=0.0,
+    )
+    assert not nx.is_directed_acyclic_graph(graph)
+    cy = roles["cycle_nodes"]["start"]
+    assert any(name.startswith("CYS") for name in cy)
+
+
+# --------------------------------------------------------------------------- #
+# generate_cyclic_graph: end-node cycles (lines 269-300)
+# --------------------------------------------------------------------------- #
+def test_end_cycle_through_existing_mediator_size_two():
+    graph, roles = cn.generate_cyclic_graph(
+        seed=21,
+        add_cycle_in_end=1,
+        cycle_size=2,
+        mediator_cycle_prob=1.0,
+    )
+    assert not nx.is_directed_acyclic_graph(graph)
+    assert "end" in roles["cycle_nodes"]
+    anchor = roles["end"][0]
+    assert any(graph.has_edge(anchor, m) and graph.has_edge(m, anchor) for m in graph.successors(anchor))
+
+
+def test_end_cycle_through_existing_mediator_size_three():
+    graph, roles = cn.generate_cyclic_graph(
+        seed=23,
+        add_cycle_in_end=1,
+        cycle_size=3,
+        mediator_cycle_prob=1.0,
+    )
+    assert not nx.is_directed_acyclic_graph(graph)
+    cy = roles["cycle_nodes"]["end"]
+    assert any(name.startswith("CYE0_") for name in cy)
+
+
+def test_end_cycle_all_fresh_nodes():
+    graph, roles = cn.generate_cyclic_graph(
+        seed=29,
+        add_cycle_in_end=2,
+        n_end=3,
+        cycle_size=3,
+        mediator_cycle_prob=0.0,
+    )
+    assert not nx.is_directed_acyclic_graph(graph)
+    cy = roles["cycle_nodes"]["end"]
+    assert any(name.startswith("CYE") for name in cy)
+
+
+# --------------------------------------------------------------------------- #
+# generate_cyclic_graph: validation errors
+# --------------------------------------------------------------------------- #
+def test_generate_cyclic_graph_rejects_small_cycle_size():
+    with pytest.raises(ValueError):
+        cn.generate_cyclic_graph(seed=1, add_cycle_in_mediators=1, cycle_size=1)
+
+
+def test_generate_cyclic_graph_rejects_too_many_start_cycles():
+    with pytest.raises(ValueError):
+        cn.generate_cyclic_graph(seed=1, add_cycle_in_start=5, n_start=2)
+
+
+def test_generate_cyclic_graph_rejects_too_many_end_cycles():
+    with pytest.raises(ValueError):
+        cn.generate_cyclic_graph(seed=1, add_cycle_in_end=5, n_end=2)
+
+
+# --------------------------------------------------------------------------- #
+# simulate_cyclic_data: threshold clamping / freeze-break (lines 383-399)
+# --------------------------------------------------------------------------- #
+def test_simulate_cyclic_data_threshold_clamps_cycle_nodes():
+    graph, roles = cn.generate_cyclic_graph(seed=5, add_cycle_in_mediators=1, cycle_size=3)
+    # A tiny threshold forces every sample of every cycle node past saturation on
+    # the first Jacobi iteration, triggering the clamp + frozen.all() break.
+    out = cn.simulate_cyclic_data(
+        graph, roles, n=25, seed=2, threshold=0.01, add_feature_var=False, verbose=False
+    )
+    cycle_nodes = roles["cycle_nodes"]["mediators"]
+    for node in cycle_nodes:
+        vals = np.asarray(out["Protein_data"][node])
+        assert np.all(np.abs(vals) <= 0.01 + 1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# simulate_cyclic_data: verbose + feature-level data path (lines 491-519)
+# --------------------------------------------------------------------------- #
+def test_simulate_cyclic_data_with_features_and_verbose(capsys):
+    graph, roles = cn.generate_cyclic_graph(seed=5, add_cycle_in_mediators=1)
+    out = cn.simulate_cyclic_data(
+        graph, roles, n=30, seed=4, add_feature_var=True, include_missing=True, verbose=True
+    )
+    import pandas as pd
+
+    assert isinstance(out["Feature_data"], pd.DataFrame)
+    assert not out["Feature_data"].empty
+    captured = capsys.readouterr()
+    assert "simulating cyclic data" in captured.out
+
+
+def test_simulate_cyclic_data_features_without_missing():
+    graph, roles = cn.generate_cyclic_graph(seed=5, add_cycle_in_mediators=1)
+    out = cn.simulate_cyclic_data(
+        graph, roles, n=30, seed=4, add_feature_var=True, include_missing=False, verbose=False
+    )
+    import pandas as pd
+
+    assert isinstance(out["Feature_data"], pd.DataFrame)
+
+
+# --------------------------------------------------------------------------- #
+# ground_truth_interventional_effect_cyclic (lines 581-653)
+# --------------------------------------------------------------------------- #
+def test_ground_truth_interventional_effect_cyclic_structure():
+    graph, roles = cn.generate_cyclic_graph(seed=5, add_cycle_in_mediators=1, cycle_size=3)
+    sim = cn.simulate_cyclic_data(graph, roles, n=20, seed=3, add_feature_var=False, verbose=False)
+    coeffs = sim["Coefficients"]
+    intervention = {roles["start"][0]: 30.0}
+    outputs = roles["end"]
+    gt = cn.ground_truth_interventional_effect_cyclic(graph, coeffs, intervention, outputs)
+    assert {"baseline", "interventional", "effect"}.issubset(gt)
+    # Baseline of every node equals its intercept.
+    for node, val in gt["baseline"].items():
+        assert val == coeffs[node]["intercept"]
+    # Effect is reported for each requested output node.
+    for node in outputs:
+        assert node in gt["effect"]
+
+
+def test_ground_truth_interventional_effect_cyclic_intervened_node_delta():
+    # The intervened node's interventional expectation must equal the do-value.
+    graph, roles = cn.generate_cyclic_graph(seed=8, add_cycle_in_mediators=1, cycle_size=3)
+    sim = cn.simulate_cyclic_data(graph, roles, n=20, seed=6, add_feature_var=False, verbose=False)
+    coeffs = sim["Coefficients"]
+    target = roles["start"][0]
+    gt = cn.ground_truth_interventional_effect_cyclic(
+        graph, coeffs, {target: 42.0}, roles["end"]
+    )
+    assert gt["interventional"][target] == 42.0
+    # A surviving multi-node SCC (the mediator cycle) must be solved and present.
+    cycle_nodes = roles["cycle_nodes"]["mediators"]
+    for node in cycle_nodes:
+        if node in coeffs:
+            assert node in gt["interventional"]
+
+
+def test_ground_truth_interventional_effect_cyclic_is_deterministic():
+    graph, roles = cn.generate_cyclic_graph(seed=8, add_cycle_in_mediators=1, cycle_size=3)
+    sim = cn.simulate_cyclic_data(graph, roles, n=20, seed=6, add_feature_var=False, verbose=False)
+    coeffs = sim["Coefficients"]
+    target = roles["start"][0]
+    a = cn.ground_truth_interventional_effect_cyclic(graph, coeffs, {target: 10.0}, roles["end"])
+    b = cn.ground_truth_interventional_effect_cyclic(graph, coeffs, {target: 10.0}, roles["end"])
+    assert a["effect"] == b["effect"]

--- a/tests/test_example_graphs.py
+++ b/tests/test_example_graphs.py
@@ -1,0 +1,73 @@
+"""Tests for the hand-built example causal graphs.
+
+Each constructor returns a dict with 'Networkx', 'y0', 'causomic', and
+'Coefficients' representations of a canonical causal structure (mediation,
+backdoor, frontdoor, signaling network). These tests pin the graph topology
+and the coefficient toggle.
+"""
+
+import importlib
+
+import networkx as nx
+import pytest
+
+eg = importlib.import_module("causomic.simulation.example_graphs")
+
+EXPECTED_KEYS = {"Networkx", "y0", "causomic", "Coefficients"}
+
+
+def test_mediator_default_topology():
+    out = eg.mediator(n_med=2)
+    assert EXPECTED_KEYS.issubset(out)
+    # X -> M1 -> M2 -> Z
+    assert set(out["Networkx"].edges()) == {("X", "M1"), ("M1", "M2"), ("M2", "Z")}
+    assert nx.is_directed_acyclic_graph(out["Networkx"])
+
+
+def test_mediator_single_mediator():
+    out = eg.mediator(n_med=1)
+    assert set(out["Networkx"].edges()) == {("X", "M1"), ("M1", "Z")}
+
+
+def test_mediator_coefficients_toggle():
+    with_coef = eg.mediator(n_med=1, include_coef=True)
+    without_coef = eg.mediator(n_med=1, include_coef=False)
+    assert with_coef["Coefficients"] is not None
+    assert set(with_coef["Coefficients"]) == set(with_coef["Networkx"].nodes())
+    assert without_coef["Coefficients"] is None
+
+
+def test_mediator_independent_nodes_added():
+    out = eg.mediator(n_med=1, add_independent_nodes=True, n_ind=5)
+    ind_nodes = [n for n in out["Networkx"].nodes() if str(n).startswith("I")]
+    assert len(ind_nodes) == 5
+
+
+def test_mediator_rejects_zero_mediators():
+    with pytest.raises(ValueError):
+        eg.mediator(n_med=0)
+
+
+def test_backdoor_topology():
+    out = eg.backdoor()
+    edges = set(out["Networkx"].edges())
+    # Confounder C into both the treatment path and outcome; X -> Y core edge.
+    assert ("X", "Y") in edges
+    assert ("C", "Y") in edges
+    assert nx.is_directed_acyclic_graph(out["Networkx"])
+
+
+def test_frontdoor_topology():
+    out = eg.frontdoor()
+    edges = set(out["Networkx"].edges())
+    # Classic frontdoor: X -> Y -> Z mediated chain with confounder C.
+    assert {("X", "Y"), ("Y", "Z")}.issubset(edges)
+    assert nx.is_directed_acyclic_graph(out["Networkx"])
+
+
+def test_signaling_network_is_dag_with_coefficients():
+    out = eg.signaling_network()
+    assert EXPECTED_KEYS.issubset(out)
+    assert nx.is_directed_acyclic_graph(out["Networkx"])
+    assert out["Networkx"].number_of_nodes() > 0
+    assert set(out["Coefficients"]) == set(out["Networkx"].nodes())

--- a/tests/test_gene_set.py
+++ b/tests/test_gene_set.py
@@ -1,9 +1,9 @@
+import json
 import os
 import sys
-import json
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 # Ensure src/ is on sys.path so tests can import the package directly
 TEST_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -55,11 +55,13 @@ def test_prep_msstats_data_handles_duplicates_and_pivot():
 
 def test_gen_correlation_matrix_basic():
     # Create a small wide dataframe where A and B are positively correlated but not perfect
-    df = pd.DataFrame({
-        "A": [1.0, 2.0, 3.0, 4.0],
-        "B": [1.1, 1.9, 3.05, 4.2],
-        "C": [10.0, 9.0, 7.0, 3.0],
-    })
+    df = pd.DataFrame(
+        {
+            "A": [1.0, 2.0, 3.0, 4.0],
+            "B": [1.1, 1.9, 3.05, 4.2],
+            "C": [10.0, 9.0, 7.0, 3.0],
+        }
+    )
 
     corr = gs.gen_correlation_matrix(df, methods=["pearson"], abs_corr=False)
     assert "pearson" in corr

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,139 @@
+"""Tests for the pure graph-processing helpers in causomic.network.
+
+Covers the causal-path filtering used to prune a posterior graph down to the
+nodes relevant to a treatment/outcome query, and the consensus-DAG aggregation
+that turns a set of bootstrap DAGs plus edge priors into a single acyclic graph.
+The INDRA/bootstrap-driven entry points (extract_indra_prior,
+estimate_posterior_dag, repair_confounding) require external services and are
+not exercised here.
+"""
+
+import importlib
+
+import networkx as nx
+import pandas as pd
+from y0.dsl import Variable
+from y0.graph import NxMixedGraph
+
+net = importlib.import_module("causomic.network")
+
+
+def _mixed_graph(directed_edges):
+    return NxMixedGraph.from_edges(directed=directed_edges)
+
+
+def test_nodes_on_causal_paths_basic_chain():
+    # X -> M -> Y, with A -> B a disconnected side chain.
+    G = _mixed_graph([("X", "M"), ("M", "Y"), ("A", "B")])
+    on_path = net.nodes_on_causal_paths(G, [Variable("X")], [Variable("Y")])
+    assert {str(n) for n in on_path} == {"X", "M", "Y"}
+
+
+def test_nodes_on_causal_paths_excludes_off_path_nodes():
+    # M lies on X->Y; D branches off X but never reaches Y.
+    G = _mixed_graph([("X", "M"), ("M", "Y"), ("X", "D")])
+    on_path = net.nodes_on_causal_paths(G, [Variable("X")], [Variable("Y")])
+    assert "D" not in {str(n) for n in on_path}
+    assert {str(n) for n in on_path} == {"X", "M", "Y"}
+
+
+def test_nodes_on_causal_paths_no_connection_is_empty():
+    # No directed path from X to Y.
+    G = _mixed_graph([("X", "M"), ("Y", "Z")])
+    on_path = net.nodes_on_causal_paths(G, [Variable("X")], [Variable("Y")])
+    assert on_path == set()
+
+
+def test_filter_to_causal_subgraph_keeps_only_path_nodes():
+    G = _mixed_graph([("X", "M"), ("M", "Y"), ("A", "B")])
+    H = net.filter_to_causal_subgraph(G, [Variable("X")], [Variable("Y")])
+    assert {str(n) for n in H.directed.nodes} == {"X", "M", "Y"}
+    assert {(str(u), str(v)) for u, v in H.directed.edges} == {("X", "M"), ("M", "Y")}
+
+
+def _priors(rows):
+    return pd.DataFrame(rows, columns=["source", "target", "edge_p"])
+
+
+def test_consensus_dag_includes_frequent_edges():
+    dags = []
+    for _ in range(4):
+        g = nx.DiGraph()
+        g.add_edge("X", "Y")
+        dags.append(g)
+    priors = _priors([("X", "Y", 0.9)])
+    out = net.consensus_dag(dags, priors, min_freq=0.5)
+    assert ("X", "Y") in out.edges()
+
+
+def test_consensus_dag_drops_infrequent_edges():
+    # X->Y in all 4 (freq 1.0); M->Y in only 1 (freq 0.25) -> dropped at min_freq=0.5.
+    dags = []
+    for i in range(4):
+        g = nx.DiGraph()
+        g.add_edge("X", "Y")
+        if i == 0:
+            g.add_edge("M", "Y")
+        dags.append(g)
+    priors = _priors([("X", "Y", 0.9), ("M", "Y", 0.9)])
+    out = net.consensus_dag(dags, priors, min_freq=0.5)
+    assert ("X", "Y") in out.edges()
+    assert ("M", "Y") not in out.edges()
+
+
+def test_consensus_dag_result_is_acyclic():
+    # Conflicting directions both appear frequently; consensus must stay acyclic.
+    dags = []
+    for _ in range(3):
+        g = nx.DiGraph()
+        g.add_edge("X", "Y")
+        g.add_edge("Y", "X")
+        dags.append(g)
+    priors = _priors([("X", "Y", 0.9), ("Y", "X", 0.9)])
+    out = net.consensus_dag(dags, priors, min_freq=0.5)
+    assert nx.is_directed_acyclic_graph(out)
+
+
+def test_extract_indra_prior_runs_and_respects_verbose(monkeypatch, capsys):
+    # Regression: extract_indra_prior referenced an undefined `verbose` at the
+    # summary-print step, raising NameError whenever called. Mock the INDRA
+    # query helpers so the function runs end-to-end without a Neo4j client.
+    one_row = pd.DataFrame(
+        {
+            "source": ["A"],
+            "target": ["B"],
+            "relation": ["IncreaseAmount"],
+            "evidence_count": [2],
+        }
+    )
+    monkeypatch.setattr(net, "get_ids", lambda names, kind: list(names))
+    monkeypatch.setattr(net, "get_one_step_root_down", lambda **kw: "q1")
+    monkeypatch.setattr(net, "get_two_step_root_known_med", lambda **kw: "q2")
+    monkeypatch.setattr(net, "get_three_step_root", lambda **kw: "q3")
+    monkeypatch.setattr(net, "format_query_results", lambda _q: one_row.copy())
+
+    result = net.extract_indra_prior(
+        source=["A"], target=["B"], measured_proteins=["A", "B"], client=object(), verbose=True
+    )
+    # Three identical mocked queries -> evidence counts summed for the A->B edge.
+    assert list(result.columns) == ["source", "target", "evidence_count"]
+    assert result.loc[0, "source"] == "A"
+    assert result.loc[0, "target"] == "B"
+    assert result.loc[0, "evidence_count"] == 6
+    assert capsys.readouterr().out != ""
+
+    net.extract_indra_prior(
+        source=["A"], target=["B"], measured_proteins=["A", "B"], client=object(), verbose=False
+    )
+    assert capsys.readouterr().out == ""
+
+
+def test_consensus_dag_ignores_none_entries():
+    dags = [None, None]
+    g = nx.DiGraph()
+    g.add_edge("X", "Y")
+    dags.append(g)
+    priors = _priors([("X", "Y", 0.9)])
+    out = net.consensus_dag(dags, priors, min_freq=0.5)
+    # Only one valid DAG, edge freq 1.0.
+    assert ("X", "Y") in out.edges()

--- a/tests/test_network_comparison.py
+++ b/tests/test_network_comparison.py
@@ -1,0 +1,51 @@
+"""Tests for the baseline structure-learning wrappers in network_comparison.
+
+The pure helpers (_model_to_nx, _standardize) are asserted directly; fit_pc and
+fit_hc are exercised on small synthetic data to confirm they return a DiGraph
+over the input variables. NOTEARS is optional and not tested here.
+"""
+
+import importlib
+
+import numpy as np
+import pandas as pd
+from pgmpy.base import DAG
+
+nc = importlib.import_module("causomic.validation.network_comparison")
+
+
+def test_model_to_nx_preserves_nodes_and_edges():
+    model = DAG()
+    model.add_nodes_from(["A", "B", "C"])
+    model.add_edges_from([("A", "B"), ("B", "C")])
+    G = nc._model_to_nx(model)
+    assert set(G.nodes()) == {"A", "B", "C"}
+    assert set(G.edges()) == {("A", "B"), ("B", "C")}
+
+
+def test_standardize_zero_mean_unit_std():
+    X = np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]])
+    Z = nc._standardize(X)
+    assert np.allclose(Z.mean(axis=0), 0.0, atol=1e-9)
+    assert np.allclose(Z.std(axis=0), 1.0, atol=1e-9)
+
+
+def _linear_chain_data(n=300, seed=0):
+    rng = np.random.default_rng(seed)
+    a = rng.normal(size=n)
+    b = 2.0 * a + rng.normal(scale=0.1, size=n)
+    c = 2.0 * b + rng.normal(scale=0.1, size=n)
+    return pd.DataFrame({"A": a, "B": b, "C": c})
+
+
+def test_fit_hc_returns_digraph_over_variables():
+    df = _linear_chain_data()
+    G, model = nc.fit_hc(df)
+    assert set(G.nodes()) == {"A", "B", "C"}
+    assert G.number_of_edges() >= 1
+
+
+def test_fit_pc_returns_digraph_over_variables():
+    df = _linear_chain_data()
+    G, model = nc.fit_pc(df)
+    assert set(G.nodes()) == {"A", "B", "C"}

--- a/tests/test_pathway_analysis.py
+++ b/tests/test_pathway_analysis.py
@@ -1,0 +1,220 @@
+"""Tests for pathway over-representation analysis (ORA) pure functions.
+
+Covers membership-matrix construction, the hypergeometric ORA, Jaccard
+similarity, greedy diverse-pathway selection, FDR correction, and JSON
+coercion. The gseapy-backed fetchers (fetch_pathway_library,
+list_pathway_libraries) hit the network and are only exercised via the
+_require_gseapy guard. All other logic is pure numpy/scipy/pandas.
+"""
+
+import importlib
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import pytest
+
+pa = importlib.import_module("causomic.data_analysis.pathway_analysis")
+
+
+# --- build_membership_matrix --------------------------------------------------
+
+
+def test_build_membership_matrix_shape_and_values():
+    universe = ["A", "B", "C", "D", "E"]
+    pathways = {"P1": ["A", "B", "C", "D", "E"]}
+    M = pa.build_membership_matrix(universe, pathways, min_pathway_size=1)
+    assert M.shape == (5, 1)
+    assert M["P1"].all()
+    assert M.dtypes["P1"] == bool
+
+
+def test_build_membership_matrix_filters_by_size():
+    universe = ["A", "B", "C", "D", "E", "F"]
+    pathways = {
+        "small": ["A", "B"],  # 2 universe genes
+        "ok": ["A", "B", "C", "D"],  # 4 universe genes
+    }
+    M = pa.build_membership_matrix(universe, pathways, min_pathway_size=3, max_pathway_size=5)
+    assert list(M.columns) == ["ok"]
+
+
+def test_build_membership_matrix_ignores_non_universe_genes():
+    universe = ["A", "B"]
+    pathways = {"P1": ["A", "B", "ZZZ"]}
+    M = pa.build_membership_matrix(universe, pathways, min_pathway_size=1)
+    assert "ZZZ" not in M.index
+    assert M["P1"].tolist() == [True, True]
+
+
+# --- run_ora ------------------------------------------------------------------
+
+
+def test_run_ora_flags_enriched_pathway():
+    pathway_dict = {
+        "P1": ["A", "B", "C", "D", "E"],
+        "P2": ["F", "G", "H", "I", "J"],
+    }
+    network = ["A", "B", "C", "D", "E"]  # perfectly overlaps P1
+    df = pa.run_ora(network, pathway_dict=pathway_dict, min_pathway_size=5)
+    assert set(df["pathway"]) == {"P1", "P2"}
+    p1 = df[df["pathway"] == "P1"].iloc[0]
+    p2 = df[df["pathway"] == "P2"].iloc[0]
+    assert p1["overlap"] == 5
+    assert p2["overlap"] == 0
+    assert p1["p_value"] < p2["p_value"]
+    # Sorted by FDR ascending -> the enriched pathway is first.
+    assert df.iloc[0]["pathway"] == "P1"
+
+
+def test_run_ora_accepts_networkx_graph():
+    g = nx.DiGraph()
+    g.add_nodes_from(["A", "B", "C", "D", "E"])
+    pathway_dict = {"P1": ["A", "B", "C", "D", "E"]}
+    df = pa.run_ora(g, pathway_dict=pathway_dict, min_pathway_size=5)
+    assert df.iloc[0]["overlap"] == 5
+    assert set(df.columns) >= {
+        "pathway",
+        "overlap",
+        "pathway_size",
+        "network_size",
+        "background_size",
+        "p_value",
+        "fdr",
+        "overlap_genes",
+    }
+
+
+def test_run_ora_empty_when_no_pathways_pass_filter():
+    pathway_dict = {"P1": ["A", "B"]}
+    df = pa.run_ora(["A"], pathway_dict=pathway_dict, min_pathway_size=5)
+    assert df.empty
+
+
+# --- compute_jaccard_from_membership ------------------------------------------
+
+
+def test_compute_jaccard_known_values():
+    # 3 genes x 2 pathways: P1={g0,g1}, P2={g1,g2} -> intersection 1, union 3.
+    M = np.array([[1, 0], [1, 1], [0, 1]], dtype=bool)
+    J = pa.compute_jaccard_from_membership(M)
+    assert J.shape == (2, 2)
+    assert J[0, 0] == 1.0 and J[1, 1] == 1.0
+    assert np.isclose(J[0, 1], 1 / 3)
+    assert np.isclose(J[0, 1], J[1, 0])
+
+
+def test_compute_jaccard_disjoint_is_zero():
+    M = np.array([[1, 0], [1, 0], [0, 1]], dtype=bool)
+    J = pa.compute_jaccard_from_membership(M)
+    assert J[0, 1] == 0.0
+
+
+# --- coverage_greedy_select ---------------------------------------------------
+
+
+def _membership_df():
+    # P1 and P3 both cover {A,B}; P2 covers {C,D}.
+    return pd.DataFrame(
+        {
+            "P1": [True, True, False, False],
+            "P2": [False, False, True, True],
+            "P3": [True, True, False, False],
+        },
+        index=["A", "B", "C", "D"],
+    )
+
+
+def test_coverage_greedy_select_covers_disjoint_pathways():
+    M = _membership_df()
+    s = pd.Series([1.0, 1.0, 1.0], index=["P1", "P2", "P3"])
+    out = pa.coverage_greedy_select(M, s, K=2, mu=0.3, max_jaccard=0.5)
+    assert len(out["selected"]) == 2
+    assert out["covered_genes"] == {"A", "B", "C", "D"}
+    # P3 duplicates P1 (Jaccard 1.0) so it is excluded under max_jaccard=0.5.
+    assert "P3" not in out["selected"]
+
+
+def test_coverage_greedy_select_respects_K():
+    M = _membership_df()
+    s = pd.Series([1.0, 1.0, 1.0], index=["P1", "P2", "P3"])
+    out = pa.coverage_greedy_select(M, s, K=1, mu=0.0)
+    assert len(out["selected"]) == 1
+
+
+# --- select_diverse_pathways --------------------------------------------------
+
+
+def test_select_diverse_pathways_filters_by_fdr():
+    ora = pd.DataFrame(
+        {
+            "pathway": ["P1", "P2"],
+            "fdr": [0.001, 0.9],
+        }
+    )
+    pathway_dict = {"P1": ["A", "B", "C", "D", "E"], "P2": ["F", "G"]}
+    background = ["A", "B", "C", "D", "E", "F", "G"]
+    out = pa.select_diverse_pathways(
+        ora, pathway_dict, background, K=5, fdr_threshold=0.05, min_pathway_size=1
+    )
+    # Only P1 passes the FDR filter, so only P1 can be selected.
+    assert out["selected"] == ["P1"]
+
+
+def test_select_diverse_pathways_empty_when_none_significant():
+    ora = pd.DataFrame({"pathway": ["P1"], "fdr": [0.9]})
+    out = pa.select_diverse_pathways(ora, {"P1": ["A", "B"]}, ["A", "B"], fdr_threshold=0.05)
+    assert out["selected"] == []
+    assert out["covered_genes"] == set()
+
+
+# --- _apply_fdr ---------------------------------------------------------------
+
+
+def test_apply_fdr_bonferroni():
+    p = np.array([0.01, 0.02])
+    out = pa._apply_fdr(p, method="bonferroni")
+    assert np.allclose(out, [0.02, 0.04])
+
+
+def test_apply_fdr_bonferroni_clipped_at_one():
+    p = np.array([0.6, 0.8])
+    out = pa._apply_fdr(p, method="bonferroni")
+    assert np.all(out <= 1.0)
+
+
+def test_apply_fdr_bh_monotone():
+    p = np.array([0.01, 0.02, 0.03])
+    out = pa._apply_fdr(p, method="bh")
+    # BH: each = min(1, p*3/rank) then step-up monotonized -> all 0.03 here.
+    assert np.allclose(out, [0.03, 0.03, 0.03])
+    # Monotone non-decreasing in the order of increasing p-value.
+    assert np.all(np.diff(out[np.argsort(p)]) >= -1e-12)
+
+
+# --- _jsonable ----------------------------------------------------------------
+
+
+def test_jsonable_passthrough_scalars():
+    assert pa._jsonable("x") == "x"
+    assert pa._jsonable(3) == 3
+    assert pa._jsonable(1.5) == 1.5
+    assert pa._jsonable(True) is True
+    assert pa._jsonable(None) is None
+
+
+def test_jsonable_collections_and_fallback():
+    assert pa._jsonable((1, 2)) == [1, 2]
+    assert pa._jsonable({1, 2}) == [1, 2] or pa._jsonable({1, 2}) == [2, 1]
+    assert pa._jsonable({"k": (1, 2)}) == {"k": [1, 2]}
+    # Non-serializable object falls back to str().
+    assert pa._jsonable(np.int64(5)) == 5 or pa._jsonable(np.int64(5)) == "5"
+
+
+# --- _require_gseapy ----------------------------------------------------------
+
+
+def test_require_gseapy_raises_when_unavailable(monkeypatch):
+    monkeypatch.setattr(pa, "_GSEAPY_AVAILABLE", False)
+    with pytest.raises(ImportError):
+        pa._require_gseapy()

--- a/tests/test_pathway_correlation_analysis.py
+++ b/tests/test_pathway_correlation_analysis.py
@@ -1,0 +1,197 @@
+"""Tests for pathway_correlation_analysis pure data-processing functions.
+
+Covers protein-name parsing, MSstats wide-format prep, correlation-matrix
+generation, and the gene-set querying helpers (which read a small JSON pathway
+fixture). All logic here is pandas/numpy/json/re -- no external services.
+"""
+
+import importlib
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pca = importlib.import_module("causomic.data_analysis.pathway_correlation_analysis")
+
+
+@pytest.fixture
+def gene_set_file(tmp_path):
+    sets = {
+        "PW1": {"geneSymbols": ["TP53", "BRCA1", "EGFR"]},
+        "PW2": {"geneSymbols": ["EGFR"]},
+    }
+    p = tmp_path / "pathways.json"
+    p.write_text(json.dumps(sets))
+    return str(p)
+
+
+# --- parse_protein_name -------------------------------------------------------
+
+
+def test_parse_protein_name_parse_gene_splits_on_underscore():
+    df = pd.DataFrame({"Protein": ["P1_HUMAN", "P2_HUMAN"]})
+    out = pca.parse_protein_name(df, parse_gene=True)
+    assert list(out["Protein"]) == ["P1", "P2"]
+
+
+def test_parse_protein_name_does_not_mutate_input():
+    df = pd.DataFrame({"Protein": ["P1_HUMAN"]})
+    pca.parse_protein_name(df, parse_gene=True)
+    assert list(df["Protein"]) == ["P1_HUMAN"]
+
+
+def test_parse_protein_name_gene_map_unmatched_becomes_nan():
+    df = pd.DataFrame({"Protein": ["P1", "P2"]})
+    gene_map = pd.DataFrame({"From": ["P1"], "To": ["G1"]})
+    out = pca.parse_protein_name(df, gene_map=gene_map)
+    assert out.loc[0, "Protein"] == "G1"
+    assert pd.isna(out.loc[1, "Protein"])
+    # merge helper columns are dropped
+    assert "From" not in out.columns and "To" not in out.columns
+
+
+# --- prep_msstats_data --------------------------------------------------------
+
+
+def test_prep_msstats_data_pivots_to_wide():
+    df = pd.DataFrame(
+        {
+            "Protein": ["A", "B"],
+            "originalRUN": ["R1", "R1"],
+            "LogIntensities": [1.0, 2.0],
+        }
+    )
+    wide = pca.prep_msstats_data(df, verbose=False)
+    assert list(wide.index) == ["R1"]
+    assert wide.loc["R1", "A"] == 1.0
+    assert wide.loc["R1", "B"] == 2.0
+
+
+def test_prep_msstats_data_averages_duplicates():
+    df = pd.DataFrame(
+        {
+            "Protein": ["A", "A"],
+            "originalRUN": ["R1", "R1"],
+            "LogIntensities": [2.0, 4.0],
+        }
+    )
+    wide = pca.prep_msstats_data(df, verbose=False)
+    assert wide.loc["R1", "A"] == 3.0
+
+
+def test_prep_msstats_data_missing_column_raises():
+    with pytest.raises(KeyError):
+        pca.prep_msstats_data(pd.DataFrame({"Protein": ["A"]}), verbose=False)
+
+
+# --- gen_correlation_matrix ---------------------------------------------------
+
+
+def test_gen_correlation_matrix_drops_self_correlations():
+    df = pd.DataFrame({"A": [1.0, 2.0, 3.0], "B": [3.0, 2.0, 1.0]})
+    out = pca.gen_correlation_matrix(df, methods=["pearson"], abs_corr=False, verbose=False)
+    corr = out["pearson"]
+    # 2 columns => only the two off-diagonal pairs survive the value<1 filter.
+    assert len(corr) == 2
+    assert set(corr["index"]) == {("A", "B"), ("B", "A")}
+    assert np.allclose(corr["value"].values, -1.0)
+
+
+def test_gen_correlation_matrix_abs_corr():
+    df = pd.DataFrame({"A": [1.0, 2.0, 3.0], "B": [3.0, 2.0, 1.0]})
+    out = pca.gen_correlation_matrix(df, methods=["pearson"], abs_corr=True, verbose=False)
+    assert np.allclose(out["pearson"]["value"].values, 1.0)
+
+
+def test_gen_correlation_matrix_invalid_method_raises():
+    df = pd.DataFrame({"A": [1.0, 2.0], "B": [2.0, 1.0]})
+    with pytest.raises(ValueError):
+        pca.gen_correlation_matrix(df, methods=["not_a_method"], verbose=False)
+
+
+# --- test_gene_sets -----------------------------------------------------------
+
+
+def _corr_frame(pairs_values):
+    """Build a correlation frame with both orderings of each pair."""
+    rows = []
+    for (a, b), v in pairs_values.items():
+        rows.append({"index": (a, b), "value": v})
+        rows.append({"index": (b, a), "value": v})
+    return pd.DataFrame(rows)
+
+
+def test_gene_sets_counts_significant_pairs(tmp_path):
+    sets = {"PW": {"geneSymbols": ["A", "B", "C"]}}
+    path = tmp_path / "pw.json"
+    path.write_text(json.dumps(sets))
+    corr = _corr_frame({("A", "B"): 0.9, ("A", "C"): 0.1, ("B", "C"): 0.1})
+    result = pca.test_gene_sets(
+        {"pearson": corr}, ["A", "B", "C"], str(path), threshold=0.5, verbose=False
+    )
+    row = result.iloc[0]
+    assert row["pathway"] == "PW"
+    assert row["total_tests"] == 3
+    assert row["sig_corrs"] == 1
+    assert row["measured_genes"] == 3
+    assert row["percent_measured"] == 1.0
+    assert np.isclose(row["percent"], 1 / 3)
+
+
+def test_gene_sets_insufficient_genes(tmp_path):
+    sets = {"PW": {"geneSymbols": ["A", "B"]}}
+    path = tmp_path / "pw.json"
+    path.write_text(json.dumps(sets))
+    corr = _corr_frame({("A", "B"): 0.9})
+    result = pca.test_gene_sets({"pearson": corr}, ["A", "B"], str(path), verbose=False)
+    assert result.iloc[0]["correlation"] == "insufficient_genes"
+    assert result.iloc[0]["total_tests"] == 0
+
+
+def test_gene_sets_invalid_fc_pval_raises(tmp_path):
+    path = tmp_path / "pw.json"
+    path.write_text(json.dumps({"PW": {"geneSymbols": ["A", "B", "C"]}}))
+    with pytest.raises(ValueError):
+        pca.test_gene_sets({"pearson": _corr_frame({})}, ["A"], str(path), fc_pval="bogus")
+
+
+# --- extract_genes_in_path ----------------------------------------------------
+
+
+def test_extract_genes_in_path_intersects_measured(gene_set_file):
+    genes = pca.extract_genes_in_path(["TP53", "XYZ"], "PW1", gene_set_file)
+    assert set(genes) == {"TP53"}
+
+
+def test_extract_genes_in_path_return_all(gene_set_file):
+    genes = pca.extract_genes_in_path(["TP53"], "PW1", gene_set_file, return_all=True)
+    assert set(genes) == {"TP53", "BRCA1", "EGFR"}
+
+
+def test_extract_genes_in_path_unknown_set_raises(gene_set_file):
+    with pytest.raises(KeyError):
+        pca.extract_genes_in_path(["TP53"], "NOPE", gene_set_file)
+
+
+# --- find_sets_with_gene ------------------------------------------------------
+
+
+def test_find_sets_with_gene_single(gene_set_file):
+    assert pca.find_sets_with_gene("TP53", gene_set_file) == ["PW1"]
+
+
+def test_find_sets_with_gene_requires_all(gene_set_file):
+    # Both TP53 and BRCA1 only co-occur in PW1.
+    assert pca.find_sets_with_gene(["TP53", "BRCA1"], gene_set_file) == ["PW1"]
+
+
+def test_find_sets_with_gene_percent_threshold(gene_set_file):
+    # EGFR is in both PW1 and PW2; threshold of 1 gene => both match.
+    result = pca.find_sets_with_gene(["TP53", "EGFR"], gene_set_file, percent=1)
+    assert set(result) == {"PW1", "PW2"}
+
+
+def test_find_sets_with_gene_bad_type_raises(gene_set_file):
+    with pytest.raises(TypeError):
+        pca.find_sets_with_gene(123, gene_set_file)

--- a/tests/test_prior_data_reconciliation.py
+++ b/tests/test_prior_data_reconciliation.py
@@ -1,0 +1,222 @@
+"""Tests for the pure helper functions in prior_data_reconciliation.
+
+Covers the deterministic / data-transform helpers only:
+
+- random_acyclic_subgraph: acyclicity, node/edge invariants, inclusion_prob
+  extremes, seeded determinism, and max_indegree enforcement.
+- calculate_edge_probabilities: power-law CDF mapping over evidence counts.
+- prepare_indra_priors: (source, target) -> probability dictionary building
+  with and without the sigmoid probability conversion.
+- remove_high_corr_edges_from_blacklist: blacklist pruning and prior augmentation
+  driven by a small correlation setup.
+
+The pgmpy scoring classes and the Parallel/HillClimb bootstrap drivers
+(process_bootstrap / run_bootstrap) are heavier and are not exercised here.
+"""
+
+import importlib
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+
+pdr = importlib.import_module("causomic.graph_construction.prior_data_reconciliation")
+
+
+# ---------------------------------------------------------------------------
+# random_acyclic_subgraph
+# ---------------------------------------------------------------------------
+def test_random_acyclic_subgraph_is_acyclic_and_subset():
+    nodes = ["A", "B", "C", "D"]
+    # Contains a cycle A->B->C->D->A; result must still be acyclic.
+    allowed = [("A", "B"), ("B", "C"), ("C", "D"), ("D", "A")]
+    rng = np.random.default_rng(0)
+    dag = pdr.random_acyclic_subgraph(nodes, allowed, inclusion_prob=1.0, rng=rng)
+    assert nx.is_directed_acyclic_graph(dag)
+    assert set(dag.nodes()) == set(nodes)
+    assert set(dag.edges()).issubset(set(allowed))
+
+
+def test_random_acyclic_subgraph_zero_prob_adds_no_edges():
+    nodes = ["A", "B", "C"]
+    allowed = [("A", "B"), ("B", "C")]
+    rng = np.random.default_rng(1)
+    dag = pdr.random_acyclic_subgraph(nodes, allowed, inclusion_prob=0.0, rng=rng)
+    assert dag.number_of_edges() == 0
+    assert set(dag.nodes()) == set(nodes)
+
+
+def test_random_acyclic_subgraph_deterministic_with_seed():
+    nodes = ["A", "B", "C", "D"]
+    allowed = [("A", "B"), ("B", "C"), ("C", "D"), ("A", "C")]
+    d1 = pdr.random_acyclic_subgraph(nodes, allowed, 0.6, np.random.default_rng(42))
+    d2 = pdr.random_acyclic_subgraph(nodes, allowed, 0.6, np.random.default_rng(42))
+    assert set(d1.edges()) == set(d2.edges())
+
+
+def test_random_acyclic_subgraph_respects_max_indegree():
+    # Every allowed edge points into node "T"; with inclusion_prob=1.0 all edges
+    # would be attempted, but max_indegree caps the accepted parents.
+    nodes = ["A", "B", "C", "T"]
+    allowed = [("A", "T"), ("B", "T"), ("C", "T")]
+    rng = np.random.default_rng(7)
+    dag = pdr.random_acyclic_subgraph(
+        nodes, allowed, inclusion_prob=1.0, rng=rng, max_indegree=1
+    )
+    assert len(dag.get_parents("T")) <= 1
+    assert nx.is_directed_acyclic_graph(dag)
+
+
+# ---------------------------------------------------------------------------
+# calculate_edge_probabilities
+# ---------------------------------------------------------------------------
+def test_calculate_edge_probabilities_cdf_properties():
+    df = pd.DataFrame(
+        {
+            "source": ["A", "B", "C", "D"],
+            "target": ["W", "X", "Y", "Z"],
+            "evidence_count": [1, 2, 5, 10],
+        }
+    )
+    mapping = pdr.calculate_edge_probabilities(df)
+
+    xmin = 1
+    xmax = 10
+    # Keys span the full integer support from xmin..xmax.
+    assert set(mapping.keys()) == set(range(xmin, xmax + 1))
+
+    values = [mapping[k] for k in range(xmin, xmax + 1)]
+    # CDF: all in [0, 1], non-decreasing, terminating at ~1.0.
+    assert all(0.0 <= v <= 1.0 for v in values)
+    assert all(a <= b + 1e-12 for a, b in zip(values, values[1:]))
+    assert np.isclose(values[-1], 1.0)
+    # Larger evidence counts receive larger cumulative probability.
+    assert mapping[10] > mapping[1]
+
+
+def test_calculate_edge_probabilities_custom_count_col():
+    df = pd.DataFrame(
+        {
+            "source": ["A", "B"],
+            "target": ["X", "Y"],
+            "source_count": [3, 7],
+        }
+    )
+    mapping = pdr.calculate_edge_probabilities(df, count_col="source_count")
+    assert set(mapping.keys()) == set(range(3, 8))
+    assert np.isclose(mapping[7], 1.0)
+
+
+# ---------------------------------------------------------------------------
+# prepare_indra_priors
+# ---------------------------------------------------------------------------
+def test_prepare_indra_priors_no_conversion_returns_raw_counts():
+    df = pd.DataFrame(
+        {
+            "source": ["AKT1", "TP53", "MDM2"],
+            "target": ["MDM2", "MDM2", "TP53"],
+            "evidence_count": [15, 25, 8],
+        }
+    )
+    priors = pdr.prepare_indra_priors(df, convert_to_probability=False)
+    assert priors == {
+        ("AKT1", "MDM2"): 15,
+        ("TP53", "MDM2"): 25,
+        ("MDM2", "TP53"): 8,
+    }
+
+
+def test_prepare_indra_priors_sigmoid_conversion():
+    df = pd.DataFrame(
+        {
+            "source": ["AKT1", "TP53"],
+            "target": ["MDM2", "MDM2"],
+            "evidence_count": [15, 25],
+        }
+    )
+    priors = pdr.prepare_indra_priors(df, convert_to_probability=True)
+
+    # Keys are the (source, target) tuples.
+    assert set(priors.keys()) == {("AKT1", "MDM2"), ("TP53", "MDM2")}
+
+    # Values match the closed-form sigmoid of log1p(count).
+    def expected(count):
+        log_ev = np.log1p(count)
+        return 1 / (1 + np.exp(-(log_ev - 1.1) / 0.552))
+
+    assert np.isclose(priors[("AKT1", "MDM2")], expected(15))
+    assert np.isclose(priors[("TP53", "MDM2")], expected(25))
+    # All resulting probabilities lie in (0, 1) and grow with evidence.
+    assert 0.0 < priors[("AKT1", "MDM2")] < priors[("TP53", "MDM2")] < 1.0
+
+
+def test_prepare_indra_priors_use_source_counts():
+    df = pd.DataFrame(
+        {
+            "source": ["A", "B"],
+            "target": ["X", "Y"],
+            "evidence_count": [1, 2],
+            "source_count": [50, 60],
+        }
+    )
+    priors = pdr.prepare_indra_priors(
+        df, convert_to_probability=False, use_source_counts=True
+    )
+    assert priors == {("A", "X"): 50, ("B", "Y"): 60}
+
+
+# ---------------------------------------------------------------------------
+# remove_high_corr_edges_from_blacklist
+# ---------------------------------------------------------------------------
+def test_remove_high_corr_edges_from_blacklist():
+    # A and B are perfectly correlated; C is anti-correlated with both.
+    data = pd.DataFrame(
+        {
+            "A": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "B": [2.0, 4.0, 6.0, 8.0, 10.0],
+            "C": [5.0, 4.0, 3.0, 2.0, 1.0],
+        }
+    )
+    indra_priors = pd.DataFrame(
+        {"source": ["A"], "target": ["C"], "evidence_count": [10]}
+    )
+    black_list = {("A", "B"), ("B", "A"), ("A", "C")}
+
+    updated_priors, updated_blacklist = pdr.remove_high_corr_edges_from_blacklist(
+        data, indra_priors, black_list, corr_threshold=0.99, verbose=False
+    )
+
+    # A<->B are highly correlated so both directions are pulled from the blacklist.
+    assert ("A", "B") not in updated_blacklist
+    assert ("B", "A") not in updated_blacklist
+    # A->C correlation is 1.0 in magnitude (perfect anti-correlation), so it is
+    # also removed given the abs-correlation threshold.
+    assert ("A", "C") not in updated_blacklist
+    assert updated_blacklist == set()
+
+    # The high-correlation edges not already present are appended to the priors.
+    prior_edges = set(zip(updated_priors["source"], updated_priors["target"]))
+    assert ("A", "B") in prior_edges
+    assert ("B", "A") in prior_edges
+    # Pre-existing (A, C) prior row is retained, not duplicated.
+    assert sum((updated_priors["source"] == "A") & (updated_priors["target"] == "C")) == 1
+
+
+def test_remove_high_corr_edges_from_blacklist_keeps_low_corr():
+    # Two independent-ish columns whose |corr| stays below the threshold.
+    data = pd.DataFrame(
+        {
+            "A": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "B": [1.0, 0.0, 1.0, 0.0, 1.0],
+        }
+    )
+    indra_priors = pd.DataFrame(
+        {"source": ["A"], "target": ["B"], "evidence_count": [3]}
+    )
+    black_list = {("A", "B")}
+
+    _, updated_blacklist = pdr.remove_high_corr_edges_from_blacklist(
+        data, indra_priors, black_list, corr_threshold=0.9, verbose=False
+    )
+    # Correlation below threshold: blacklist edge is preserved.
+    assert ("A", "B") in updated_blacklist

--- a/tests/test_proteomics_processor.py
+++ b/tests/test_proteomics_processor.py
@@ -1,4 +1,5 @@
 import importlib
+
 import numpy as np
 import pandas as pd
 

--- a/tests/test_proteomics_simulator.py
+++ b/tests/test_proteomics_simulator.py
@@ -1,0 +1,162 @@
+"""Tests for the proteomics data simulator.
+
+These exercise the synthetic data-generation pipeline: structural-equation
+coefficient generation, node/data simulation over a causal graph, feature-level
+expansion, missing-data masking, and the built-in IGF example network. Data is
+constructed inline (small DiGraphs / arrays) following the suite convention.
+"""
+
+import importlib
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+
+# src is placed on sys.path by tests/conftest.py
+ps = importlib.import_module("causomic.simulation.proteomics_simulator")
+
+
+def chain_graph():
+    """Simple linear causal chain X -> Y -> Z."""
+    return nx.DiGraph([("X", "Y"), ("Y", "Z")])
+
+
+# --------------------------------------------------------------------------- #
+# Coefficient generation
+# --------------------------------------------------------------------------- #
+def test_generate_coefficients_has_entry_per_node():
+    G = chain_graph()
+    coeffs = ps.generate_coefficients(G)
+
+    assert set(coeffs) == set(G.nodes())
+    # Root node: only intercept + error, no parent terms.
+    assert set(coeffs["X"]) == {"intercept", "error"}
+    # Child nodes carry a coefficient for each parent plus intercept + error.
+    assert set(coeffs["Y"]) == {"X", "intercept", "error"}
+    assert set(coeffs["Z"]) == {"Y", "intercept", "error"}
+
+
+def test_generate_node_coefficients_root_vs_child():
+    root = ps.generate_node_coefficients([])
+    assert set(root) == {"intercept", "error"}
+    # Root intercepts represent baseline expression in the 15-25 range.
+    assert 15 <= root["intercept"] <= 25
+
+    child = ps.generate_node_coefficients(["A", "B"])
+    assert {"A", "B", "intercept", "error"}.issubset(child)
+
+
+# --------------------------------------------------------------------------- #
+# simulate_data
+# --------------------------------------------------------------------------- #
+def test_simulate_data_structure_and_shapes():
+    G = chain_graph()
+    out = ps.simulate_data(G, n=50, seed=1, verbose=False)
+
+    assert set(out) == {"Protein_data", "Feature_data", "Coefficients"}
+    assert set(out["Protein_data"]) == set(G.nodes())
+    for node in G.nodes():
+        assert np.asarray(out["Protein_data"][node]).shape == (50,)
+
+    expected_cols = {
+        "Protein",
+        "Replicate",
+        "Feature",
+        "Intensity",
+        "Obs_Intensity",
+        "MNAR_threshold",
+        "MAR",
+        "MNAR",
+    }
+    assert expected_cols.issubset(out["Feature_data"].columns)
+
+
+def test_simulate_data_is_reproducible_with_seed():
+    G = chain_graph()
+    a = ps.simulate_data(G, n=40, seed=7, verbose=False)
+    b = ps.simulate_data(G, n=40, seed=7, verbose=False)
+
+    for node in G.nodes():
+        assert np.allclose(a["Protein_data"][node], b["Protein_data"][node])
+
+
+def test_simulate_data_without_feature_variation():
+    G = chain_graph()
+    out = ps.simulate_data(G, n=20, seed=1, add_feature_var=False, verbose=False)
+    assert out["Feature_data"] is None
+
+
+def test_simulate_data_missingness_toggle():
+    G = chain_graph()
+    with_missing = ps.simulate_data(G, n=200, seed=3, verbose=False)
+    without_missing = ps.simulate_data(G, n=200, seed=3, include_missing=False, verbose=False)
+
+    # With masking enabled, the observed intensity is present and carries NaNs.
+    assert "Obs_Intensity" in with_missing["Feature_data"].columns
+    assert with_missing["Feature_data"]["Obs_Intensity"].isna().any()
+
+    # With masking disabled, no masking is applied and the mask columns
+    # (including Obs_Intensity) are never added.
+    assert "Obs_Intensity" not in without_missing["Feature_data"].columns
+
+
+def test_simulate_data_intervention_pins_node():
+    G = chain_graph()
+    out = ps.simulate_data(
+        G, n=30, seed=2, intervention={"X": 7.0}, add_feature_var=False, verbose=False
+    )
+    assert np.allclose(out["Protein_data"]["X"], 7.0)
+
+
+# --------------------------------------------------------------------------- #
+# Lower-level helpers
+# --------------------------------------------------------------------------- #
+def test_simulate_node_returns_expected_length():
+    np.random.seed(0)
+    arr = ps.simulate_node({}, {"intercept": 10.0, "error": 1.0}, 40, False, None, "X")
+    assert np.asarray(arr).shape == (40,)
+
+
+def test_generate_features_columns_and_protein_label():
+    np.random.seed(0)
+    feats = ps.generate_features(np.random.normal(10, 1, 25), "X")
+    assert isinstance(feats, pd.DataFrame)
+    assert {"Protein", "Replicate", "Feature", "Intensity"}.issubset(feats.columns)
+    assert set(feats["Protein"].unique()) == {"X"}
+
+
+def test_add_missing_appends_mask_columns():
+    df = pd.DataFrame(
+        {
+            "Protein": ["X"] * 20,
+            "Feature": ["f"] * 20,
+            "Replicate": range(20),
+            "Intensity": np.linspace(5, 20, 20),
+        }
+    )
+    out = ps.add_missing(df.copy(), 0.05, [-3, 0.4])
+    for col in ("Obs_Intensity", "MNAR_threshold", "MAR", "MNAR"):
+        assert col in out.columns
+
+
+# --------------------------------------------------------------------------- #
+# Built-in example network
+# --------------------------------------------------------------------------- #
+def test_build_igf_network_is_dag():
+    G = ps.build_igf_network(cell_confounder=False)
+    assert isinstance(G, nx.DiGraph)
+    assert nx.is_directed_acyclic_graph(G)
+    assert G.number_of_nodes() > 0
+
+
+def test_build_igf_network_confounder_adds_nodes():
+    base = ps.build_igf_network(cell_confounder=False)
+    confounded = ps.build_igf_network(cell_confounder=True)
+    assert confounded.number_of_nodes() >= base.number_of_nodes()
+
+
+def test_simulate_data_end_to_end_on_igf_network():
+    G = ps.build_igf_network(cell_confounder=False)
+    out = ps.simulate_data(G, n=50, seed=11, verbose=False)
+    assert set(out["Protein_data"]) == set(G.nodes())
+    assert len(out["Feature_data"]) > 0

--- a/tests/test_random_network.py
+++ b/tests/test_random_network.py
@@ -1,0 +1,129 @@
+"""Tests for procedural DAG generation and INDRA-style misspecification.
+
+Covers random and structured DAG generation, ground-truth interventional
+effect computation over a known structure, generation of a misspecified
+"INDRA" graph from a ground-truth DAG, and conversion of that graph into an
+evidence-annotated graph.
+"""
+
+import importlib
+
+import networkx as nx
+import numpy as np
+import pytest
+
+rn = importlib.import_module("causomic.simulation.random_network")
+eg = importlib.import_module("causomic.simulation.example_graphs")
+
+
+# --------------------------------------------------------------------------- #
+# generate_random_dag
+# --------------------------------------------------------------------------- #
+def test_generate_random_dag_is_acyclic():
+    dag = rn.generate_random_dag(8, 0.5)
+    assert isinstance(dag, nx.DiGraph)
+    assert dag.number_of_nodes() == 8
+    assert nx.is_directed_acyclic_graph(dag)
+
+
+def test_generate_random_dag_sparsity_extremes():
+    empty = rn.generate_random_dag(6, 0.0)
+    full = rn.generate_random_dag(6, 1.0)
+    assert empty.number_of_edges() == 0
+    # sparsity 1.0 connects every valid forward pair (upper triangular).
+    assert full.number_of_edges() == 6 * (6 - 1) // 2
+
+
+# --------------------------------------------------------------------------- #
+# generate_structured_dag
+# --------------------------------------------------------------------------- #
+def test_generate_structured_dag_roles_and_acyclic():
+    dag, roles = rn.generate_structured_dag(seed=1)
+    assert nx.is_directed_acyclic_graph(dag)
+    assert {"start", "end", "mediators", "confounders"}.issubset(roles)
+    # Start (ligand) and end (readout) nodes must exist.
+    assert len(roles["start"]) > 0
+    assert len(roles["end"]) > 0
+
+
+def test_generate_structured_dag_is_reproducible():
+    dag_a, _ = rn.generate_structured_dag(seed=42)
+    dag_b, _ = rn.generate_structured_dag(seed=42)
+    assert set(dag_a.edges()) == set(dag_b.edges())
+
+
+# --------------------------------------------------------------------------- #
+# ground_truth_interventional_effect
+# --------------------------------------------------------------------------- #
+def test_ground_truth_interventional_effect_structure():
+    med = eg.mediator(n_med=1)
+    gt = rn.ground_truth_interventional_effect(
+        med["Networkx"], med["Coefficients"], {"X": 5.0}, ["Z"]
+    )
+    assert {"baseline", "interventional", "effect"}.issubset(gt)
+    # Effect should be reported for the requested output node.
+    assert "Z" in gt["effect"]
+
+
+# --------------------------------------------------------------------------- #
+# generate_indra_data / indra_dag_to_evidence_graph
+# --------------------------------------------------------------------------- #
+def test_generate_indra_data_adds_misspecification():
+    gt_dag, _ = rn.generate_structured_dag(seed=2)
+    indra_dag, edge_df, added = rn.generate_indra_data(
+        gt_dag, num_incorrect_nodes=3, num_incorrect_edges=5
+    )
+    assert isinstance(indra_dag, nx.DiGraph)
+    # Incorrect nodes are added, so the misspecified graph is at least as large.
+    assert indra_dag.number_of_nodes() >= gt_dag.number_of_nodes()
+
+
+def test_indra_dag_to_evidence_graph_annotates_edges():
+    gt_dag, _ = rn.generate_structured_dag(seed=2)
+    indra_dag, _, _ = rn.generate_indra_data(gt_dag, num_incorrect_nodes=3, num_incorrect_edges=5)
+    ev_graph = rn.indra_dag_to_evidence_graph(indra_dag)
+    assert isinstance(ev_graph, nx.DiGraph)
+    assert ev_graph.number_of_edges() > 0
+    for _, _, data in ev_graph.edges(data=True):
+        assert "evidence" in data
+        assert "evidence_count" in data
+        assert "ground_truth" in data
+
+
+# --------------------------------------------------------------------------- #
+# generate_indra_data: optional misspecification branches
+# --------------------------------------------------------------------------- #
+def test_generate_indra_data_preferential_and_shortcut_and_missing():
+    # Exercises the preferential-attachment edge branch, the mediated-shortcut
+    # branch, and the p_missing_real edge-dropping branch together.
+    np.random.seed(0)
+    gt_dag, _ = rn.generate_structured_dag(seed=4)
+    indra_dag, edge_df, missing = rn.generate_indra_data(
+        gt_dag,
+        num_incorrect_nodes=4,
+        num_incorrect_edges=8,
+        p_missing_real=0.3,
+        p_mediated_shortcut=0.5,
+        preferential_attachment=True,
+        start_node_out_mu=2.0,
+    )
+    assert isinstance(indra_dag, nx.DiGraph)
+    assert set(edge_df.columns) == {"source", "target", "ground_truth", "evidence_count"}
+    assert (edge_df["evidence_count"] >= 1).all()
+    # missing_edges is a subset of the original ground-truth edges.
+    for u, v in missing:
+        assert gt_dag.has_edge(u, v)
+
+
+# --------------------------------------------------------------------------- #
+# run_graph_sim (end-to-end smoke test, lines 594-800)
+# --------------------------------------------------------------------------- #
+def test_run_graph_sim_returns_metric_octuple():
+    # Full recovery pipeline (causomic + PC + HC + NOTEARS). Self-seeded via
+    # secrets, so we assert on structure/ranges rather than exact values.
+    result = rn.run_graph_sim(verbose=False)
+    assert isinstance(result, tuple)
+    assert len(result) == 8
+    for metric in result:
+        val = float(metric)
+        assert 0.0 <= val <= 1.0

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,0 +1,172 @@
+"""Tests for the pure/synthetic-data-testable helpers in
+causomic.graph_construction.repair.
+
+Two functions are exercised here:
+
+* ``convert_to_y0_graph`` is a pure transformation from a posterior-DAG
+  DataFrame (with 'source'/'target' columns) into a y0 ``NxMixedGraph``. The
+  tests pin that nodes and directed edges are preserved (y0 stores nodes as
+  ``Variable`` objects, so comparisons go through ``str(...)``).
+
+* ``process_failed_test`` runs pearsonr-based conditional-independence tests on
+  synthetic data to decide whether a failed CI test can be repaired by adding
+  observed confounders or whether a latent confounder must be introduced. The
+  tests build data with a genuine common cause (repair path) and with a direct
+  dependency plus an unrelated candidate (latent path).
+
+The INDRA/Neo4j-driven callers are not exercised here.
+"""
+
+import importlib
+
+import numpy as np
+import pandas as pd
+
+repair = importlib.import_module("causomic.graph_construction.repair")
+
+
+def _posterior_dag(edges):
+    return pd.DataFrame(edges, columns=["source", "target"])
+
+
+def test_convert_to_y0_graph_preserves_nodes_and_edges():
+    dag = _posterior_dag([("X", "M"), ("M", "Y")])
+    g = repair.convert_to_y0_graph(dag)
+
+    assert {str(n) for n in g.directed.nodes} == {"X", "M", "Y"}
+    assert {(str(u), str(v)) for u, v in g.directed.edges} == {("X", "M"), ("M", "Y")}
+
+
+def test_convert_to_y0_graph_handles_branching_and_no_latents():
+    # A branching DAG: all nodes are observed, so no bidirected (latent) edges.
+    dag = _posterior_dag([("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")])
+    g = repair.convert_to_y0_graph(dag)
+
+    assert {str(n) for n in g.directed.nodes} == {"A", "B", "C", "D"}
+    assert {(str(u), str(v)) for u, v in g.directed.edges} == {
+        ("A", "B"),
+        ("A", "C"),
+        ("B", "D"),
+        ("C", "D"),
+    }
+    # Every node was marked observed, so nothing gets lifted into the ADMG's
+    # undirected/bidirected component.
+    assert len(list(g.undirected.edges)) == 0
+
+
+def test_convert_to_y0_graph_ignores_stale_index():
+    # A non-default index must not break the positional .loc access.
+    dag = _posterior_dag([("X", "Y"), ("Y", "Z")])
+    dag.index = [10, 20]
+    g = repair.convert_to_y0_graph(dag)
+
+    assert {(str(u), str(v)) for u, v in g.directed.edges} == {("X", "Y"), ("Y", "Z")}
+
+
+def test_process_failed_test_finds_confounder_and_repairs():
+    # Z is a genuine common cause of both S and T; given Z they are
+    # conditionally independent, so the failed test should be repaired by
+    # adding Z rather than a latent confounder.
+    rng = np.random.default_rng(0)
+    n = 2000
+    z = rng.normal(size=n)
+    data = pd.DataFrame(
+        {
+            "S": 2.0 * z + rng.normal(scale=0.5, size=n),
+            "T": 3.0 * z + rng.normal(scale=0.5, size=n),
+            "Z": z,
+        }
+    )
+    row = pd.Series({"left": "S", "right": "T", "given": ""})
+    confounder_relations = {("S", "T"): ["Z"]}
+
+    result = repair.process_failed_test(row, confounder_relations, data, max_conditional=2)
+
+    assert result["source"] == "S"
+    assert result["target"] == "T"
+    assert result["add_latent"] is False
+    assert result["Z"] == ("Z",)
+    assert "error" not in result
+
+
+def test_process_failed_test_no_confounder_restores_independence_adds_latent():
+    # S drives T directly; the only candidate confounder W is pure noise and
+    # cannot render S and T independent, so a latent confounder is proposed.
+    rng = np.random.default_rng(1)
+    n = 2000
+    s = rng.normal(size=n)
+    data = pd.DataFrame(
+        {
+            "S": s,
+            "T": 2.0 * s + rng.normal(scale=0.5, size=n),
+            "W": rng.normal(size=n),
+        }
+    )
+    row = pd.Series({"left": "S", "right": "T", "given": ""})
+    confounder_relations = {("S", "T"): ["W"]}
+
+    result = repair.process_failed_test(row, confounder_relations, data, max_conditional=2)
+
+    assert result["source"] == "S"
+    assert result["target"] == "T"
+    assert result["add_latent"] is True
+    assert result["Z"] is None
+    assert "error" not in result
+
+
+def test_process_failed_test_no_candidates_adds_latent():
+    # When no usable confounders exist there are no combos to test, so the
+    # function short-circuits to proposing a latent confounder.
+    rng = np.random.default_rng(2)
+    n = 500
+    data = pd.DataFrame(
+        {
+            "S": rng.normal(size=n),
+            "T": rng.normal(size=n),
+        }
+    )
+    row = pd.Series({"left": "S", "right": "T", "given": ""})
+    confounder_relations = {("S", "T"): []}
+
+    result = repair.process_failed_test(row, confounder_relations, data)
+
+    assert result["add_latent"] is True
+    assert result["Z"] is None
+
+
+def test_process_failed_test_drops_given_and_missing_candidates():
+    # Candidates equal to 'given' or absent from the data are filtered out.
+    # Here only the given variable and an unknown column are offered, leaving
+    # no testable candidate -> latent confounder.
+    rng = np.random.default_rng(3)
+    n = 500
+    g = rng.normal(size=n)
+    data = pd.DataFrame(
+        {
+            "S": g + rng.normal(scale=0.5, size=n),
+            "T": g + rng.normal(scale=0.5, size=n),
+            "G": g,
+        }
+    )
+    row = pd.Series({"left": "S", "right": "T", "given": "G"})
+    confounder_relations = {("S", "T"): ["G", "NOT_IN_DATA"]}
+
+    result = repair.process_failed_test(row, confounder_relations, data)
+
+    assert result["add_latent"] is True
+    assert result["Z"] is None
+
+
+def test_process_failed_test_missing_relation_returns_error_latent():
+    # A missing (source, target) key raises a KeyError internally; the function
+    # catches it, marks add_latent and reports the error string.
+    data = pd.DataFrame({"S": [0.0, 1.0], "T": [1.0, 0.0]})
+    row = pd.Series({"left": "S", "right": "T", "given": ""})
+
+    result = repair.process_failed_test(row, {}, data)
+
+    assert result["source"] == "S"
+    assert result["target"] == "T"
+    assert result["add_latent"] is True
+    assert result["Z"] is None
+    assert "error" in result

--- a/tests/test_search_path_diagnostic.py
+++ b/tests/test_search_path_diagnostic.py
@@ -1,0 +1,77 @@
+"""Tests for the pure helpers in search_path_diagnostic.
+
+random_acyclic_subgraph and compare_dag_sets are deterministic given a seeded
+RNG and fixed DAG sets; the Parallel/HillClimb-driven search_path_diagnostic
+itself needs an estimator and is not exercised here.
+"""
+
+import importlib
+
+import networkx as nx
+import numpy as np
+from pgmpy.base import DAG
+
+spd = importlib.import_module("causomic.graph_construction.search_path_diagnostic")
+
+
+def test_random_acyclic_subgraph_is_acyclic_and_subset():
+    nodes = ["A", "B", "C", "D"]
+    allowed = [("A", "B"), ("B", "C"), ("C", "D"), ("D", "A")]
+    rng = np.random.default_rng(0)
+    dag = spd.random_acyclic_subgraph(nodes, allowed, inclusion_prob=1.0, rng=rng)
+    assert nx.is_directed_acyclic_graph(dag)
+    assert set(dag.nodes()) == set(nodes)
+    assert set(dag.edges()).issubset(set(allowed))
+
+
+def test_random_acyclic_subgraph_zero_prob_adds_no_edges():
+    nodes = ["A", "B", "C"]
+    allowed = [("A", "B"), ("B", "C")]
+    rng = np.random.default_rng(1)
+    dag = spd.random_acyclic_subgraph(nodes, allowed, inclusion_prob=0.0, rng=rng)
+    assert dag.number_of_edges() == 0
+    assert set(dag.nodes()) == set(nodes)
+
+
+def test_random_acyclic_subgraph_deterministic_with_seed():
+    nodes = ["A", "B", "C", "D"]
+    allowed = [("A", "B"), ("B", "C"), ("C", "D"), ("A", "C")]
+    d1 = spd.random_acyclic_subgraph(nodes, allowed, 0.6, np.random.default_rng(42))
+    d2 = spd.random_acyclic_subgraph(nodes, allowed, 0.6, np.random.default_rng(42))
+    assert set(d1.edges()) == set(d2.edges())
+
+
+def _dag(edges):
+    d = DAG()
+    d.add_edges_from(edges)
+    return d
+
+
+def test_compare_dag_sets_frequencies_and_diff():
+    # Edge A->B in all of set-a, only half of set-b.
+    dags_a = [_dag([("A", "B")]), _dag([("A", "B")])]
+    dags_b = [_dag([("A", "B")]), _dag([("C", "D")])]
+    df = spd.compare_dag_sets(dags_a, dags_b)
+    row_ab = df[(df["source"] == "A") & (df["target"] == "B")].iloc[0]
+    assert row_ab["freq_random_init"] == 1.0
+    assert row_ab["freq_bootstrap"] == 0.5
+    assert np.isclose(row_ab["abs_diff"], 0.5)
+    # Both distinct edges represented.
+    assert set(zip(df["source"], df["target"])) == {("A", "B"), ("C", "D")}
+
+
+def test_compare_dag_sets_sorted_by_abs_diff_desc():
+    dags_a = [_dag([("A", "B"), ("C", "D")])]
+    dags_b = [_dag([("C", "D")])]
+    df = spd.compare_dag_sets(dags_a, dags_b)
+    # A->B differs by 1.0, C->D by 0.0; the larger diff sorts first.
+    assert df.iloc[0]["source"] == "A"
+    assert df["abs_diff"].is_monotonic_decreasing
+
+
+def test_compare_dag_sets_custom_labels():
+    dags_a = [_dag([("A", "B")])]
+    dags_b = [_dag([("A", "B")])]
+    df = spd.compare_dag_sets(dags_a, dags_b, label_a="rand", label_b="boot")
+    assert "freq_rand" in df.columns
+    assert "freq_boot" in df.columns

--- a/tests/test_utils_nx.py
+++ b/tests/test_utils_nx.py
@@ -15,9 +15,29 @@ def make_sample_graph():
         G.add_node(n, ns="HGNC")
 
     # edges with statements list (dicts)
-    G.add_edge("n1", "n2", statements=[{"stmt_type": "IncreaseAmount", "evidence_count": 2, "source_counts": {"SRC1": 1}}])
-    G.add_edge("n2", "n3", statements=[{"stmt_type": "DecreaseAmount", "evidence_count": 5, "source_counts": {"SRC1": 2, "SRC2": 1}}])
-    G.add_edge("n3", "n4", statements=[{"stmt_type": "OtherType", "evidence_count": None, "source_counts": {}}])
+    G.add_edge(
+        "n1",
+        "n2",
+        statements=[
+            {"stmt_type": "IncreaseAmount", "evidence_count": 2, "source_counts": {"SRC1": 1}}
+        ],
+    )
+    G.add_edge(
+        "n2",
+        "n3",
+        statements=[
+            {
+                "stmt_type": "DecreaseAmount",
+                "evidence_count": 5,
+                "source_counts": {"SRC1": 2, "SRC2": 1},
+            }
+        ],
+    )
+    G.add_edge(
+        "n3",
+        "n4",
+        statements=[{"stmt_type": "OtherType", "evidence_count": None, "source_counts": {}}],
+    )
 
     return G
 
@@ -68,10 +88,22 @@ def test_query_confounders_returns_dataframe():
     # attach evidence info first
     utils_nx.add_evidence_info(G)
     # create a common confounder node that points to n2 and n3
-    G.add_edge("c", "n2", statements=[{"stmt_type": "IncreaseAmount", "evidence_count": 3, "source_counts": {"S1": 1}}])
-    G.add_edge("c", "n3", statements=[{"stmt_type": "IncreaseAmount", "evidence_count": 4, "source_counts": {"S1": 1}}])
+    G.add_edge(
+        "c",
+        "n2",
+        statements=[
+            {"stmt_type": "IncreaseAmount", "evidence_count": 3, "source_counts": {"S1": 1}}
+        ],
+    )
+    G.add_edge(
+        "c",
+        "n3",
+        statements=[
+            {"stmt_type": "IncreaseAmount", "evidence_count": 4, "source_counts": {"S1": 1}}
+        ],
+    )
     utils_nx.add_evidence_info(G)
-    df = utils_nx.query_confounders(G, ["n2", "n3"]) 
+    df = utils_nx.query_confounders(G, ["n2", "n3"])
     assert isinstance(df, pd.DataFrame)
     # should contain rows for the confounder 'c'
     assert (df["source"] == "c").any()
@@ -79,26 +111,72 @@ def test_query_confounders_returns_dataframe():
 
 def test_filtered_paths_and_query_forward_paths():
     G = nx.DiGraph()
-    G.add_edges_from([
-        ("A", "B", {"evidence": {"total_evidence": 2, "source_evidence": 1}}),
-        ("B", "C", {"evidence": {"total_evidence": 2, "source_evidence": 1}}),
-    ])
+    G.add_edges_from(
+        [
+            (
+                "A",
+                "B",
+                {
+                    "evidence": {
+                        "total_evidence": 2,
+                        "source_evidence": 1,
+                        "stmt_type": ["IncreaseAmount"],
+                    }
+                },
+            ),
+            (
+                "B",
+                "C",
+                {
+                    "evidence": {
+                        "total_evidence": 2,
+                        "source_evidence": 1,
+                        "stmt_type": ["IncreaseAmount"],
+                    }
+                },
+            ),
+        ]
+    )
     # filtered_paths yields the path A->B->C
     paths = list(utils_nx.filtered_paths(G, "A", "C", cutoff=2, thr=1))
     assert any(path for path in paths if path[0] == "A" and path[-1] == "C")
 
     # query_forward_paths should return dataframe with the forward edges
-    fwd = utils_nx.query_forward_paths(G, start_nodes=["A"], end_nodes=["C"], n_mediators=2, med_ev_filter=[1, 1, 1])
+    fwd = utils_nx.query_forward_paths(
+        G, start_nodes=["A"], end_nodes=["C"], n_mediators=2, med_ev_filter=[1, 1, 1]
+    )
     assert isinstance(fwd, pd.DataFrame)
     assert set(["source", "target"]).issubset(fwd.columns)
 
 
 def test_query_forward_paths_counts_mediators_not_edges():
     G = nx.DiGraph()
-    G.add_edges_from([
-        ("A", "B", {"evidence": {"total_evidence": 2, "source_evidence": 1}}),
-        ("B", "C", {"evidence": {"total_evidence": 2, "source_evidence": 1}}),
-    ])
+    G.add_edges_from(
+        [
+            (
+                "A",
+                "B",
+                {
+                    "evidence": {
+                        "total_evidence": 2,
+                        "source_evidence": 1,
+                        "stmt_type": ["IncreaseAmount"],
+                    }
+                },
+            ),
+            (
+                "B",
+                "C",
+                {
+                    "evidence": {
+                        "total_evidence": 2,
+                        "source_evidence": 1,
+                        "stmt_type": ["IncreaseAmount"],
+                    }
+                },
+            ),
+        ]
+    )
 
     direct_only = utils_nx.query_forward_paths(
         G,

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,66 @@
+"""Tests for the pure helper utilities in causomic.workflows.
+
+The public run_toxicity_detection_workflow requires INDRA queries and structure
+learning, so it is not exercised here; these tests pin the graph-counting and
+drug-name-normalization helpers plus the no-op logging path.
+"""
+
+import importlib
+
+import networkx as nx
+import pandas as pd
+
+wf = importlib.import_module("causomic.workflows")
+
+
+def test_graph_counts_dataframe():
+    df = pd.DataFrame({"source": ["A", "B"], "target": ["B", "C"]})
+    assert wf._graph_counts(df) == (3, 2, None)
+
+
+def test_graph_counts_networkx():
+    g = nx.DiGraph([("A", "B"), ("B", "C")])
+    assert wf._graph_counts(g) == (3, 2, None)
+
+
+def test_graph_counts_mixed_graph_splits_edge_types():
+    from y0.graph import NxMixedGraph
+
+    G = NxMixedGraph.from_edges(directed=[("A", "B")], undirected=[("B", "C")])
+    nodes, edges, split = wf._graph_counts(G)
+    assert nodes == 3
+    assert edges == 2
+    assert split == (1, 1)
+
+
+def test_graph_counts_unsupported_returns_none():
+    assert wf._graph_counts(42) == (None, None, None)
+
+
+def test_normalize_drug_name_str():
+    assert wf._normalize_drug_name("aspirin") == "aspirin"
+
+
+def test_normalize_drug_name_list():
+    assert wf._normalize_drug_name(["a", "b"]) == "a,b"
+
+
+def test_normalize_drug_name_tuple():
+    assert wf._normalize_drug_name(("a", "b")) == "a,b"
+
+
+def test_normalize_drug_name_other():
+    assert wf._normalize_drug_name(5) == "5"
+
+
+def test_append_log_line_none_is_noop(tmp_path):
+    # log_file=None must not create any file or raise.
+    wf._append_log_line("hello", None)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_append_log_line_writes(tmp_path):
+    log_file = tmp_path / "sub" / "run.log"
+    wf._append_log_line("line one", str(log_file))
+    assert log_file.exists()
+    assert "line one" in log_file.read_text()


### PR DESCRIPTION
Tests: expand from 52 to 154 passing tests across the package (network, pathway analysis, workflows, repair, prior reconciliation, simulation, and comparison modules).

Fixes:
- network.py: add missing `verbose` param to extract_indra_prior (referenced an undefined name -> NameError on every call)
- models.py: correct `node_name not in "Output"` substring checks to `"Output" not in node_name`, matching the read-site predicates

Chore: add CI workflow (lint + pytest + Codecov upload), coverage badge, LICENSE/CONTRIBUTING/CHANGELOG, and point all repo URLs at Vitek-Lab/Causomic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and context
This change expands the package with broader analysis, simulation, validation, and workflow support while adding substantial test coverage. It also fixes two latent bugs: an undefined `verbose` reference in `extract_indra_prior`, and incorrect `"Output"` substring checks in the causal model code. In parallel, the repository is made more production-ready with CI, packaging, documentation, and branding updates.

## Changes
- Added CI for linting, pytest, and Codecov upload.
- Expanded package metadata and tooling:
  - new test/dev extras
  - pytest config
  - updated Black targets
  - MIT license field
- Updated repository URLs and README branding to `Vitek-Lab/Causomic`.
- Added repository docs:
  - `LICENSE`
  - `CONTRIBUTING.md`
  - `CHANGELOG.md`
- Added/expanded public package exports across:
  - `causal_model`
  - `data_analysis`
  - `graph_construction`
  - `simulation`
  - `validation`
- Added new pathway analysis utilities:
  - ORA
  - pathway library lookup
  - greedy diverse pathway selection
  - Cytoscape export
- Added verbose flags to multiple workflows and helpers to reduce noisy console output.
- Fixed `extract_indra_prior` by adding the missing `verbose` parameter.
- Fixed `"Output"` node detection logic in `models.py`.
- Refactored simulation and workflow modules, including removal of several old `main()` demo entry points.
- Tightened `.gitignore` for local dev artifacts.

## Tests
Added or expanded coverage for:
- cyclic network generation and cyclic simulation
- example graph constructors
- network helpers and INDRA prior extraction
- pathway analysis utilities
- pathway correlation analysis
- prior data reconciliation
- proteomics simulation and processing
- random network generation
- repair utilities
- search-path diagnostics
- workflow helper functions

## Coding guidelines violated
None identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->