### PR TITLE
Drop Python 3.10 support (require 3.11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ First publicly packaged release, focused on publication readiness.
 - PyPI packaging metadata: trove `classifiers` and search `keywords`.
 
 ### Changed
-- Set the supported Python range to 3.10–3.11 (`requires-python = ">=3.10,<3.12"`).
+- Set the supported Python version to 3.11 (`requires-python = ">=3.11,<3.12"`).
+  3.10 is not supported because the only cleanly-installable `pysb` (1.17.0, the
+  sole version shipping a wheel; earlier sdists fail to build) requires 3.11.
 - Install `indra` from PyPI instead of a `git+` URL, so the package can be
   published to PyPI (no direct-URL dependencies remain).
 - Made `indra-cogex` an optional dependency: its imports are now guarded, so the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ development environment, the conventions we follow, and how to submit changes.
 
 ## Development setup
 
-Causomic targets Python 3.10–3.11 and depends on PyTorch 2.0.1 and Pyro. We
+Causomic targets Python 3.11 and depends on PyTorch 2.0.1 and Pyro. We
 recommend a clean virtual environment.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Causomic
 
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11-blue.svg)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/)
 [![codecov](https://codecov.io/gh/Vitek-Lab/Causomic/branch/main/graph/badge.svg)](https://codecov.io/gh/Vitek-Lab/Causomic)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Development Status](https://img.shields.io/badge/status-development-orange.svg)](https://github.com/Vitek-Lab/Causomic)
@@ -72,7 +72,7 @@ The package is particularly useful for:
 ## Installation
 
 ### Prerequisites
-- Python 3.10 or 3.11
+- Python 3.11
 - PyTorch 2.0.1
 - Pyro-PPL
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.9.0"
 description = "Python code for causal modeling of proteomics data."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.11,<3.12"
 
 authors = [
 	{ name = "Devon Kohler", email = "kohler.d@northeastern.edu" },
@@ -40,7 +40,6 @@ classifiers = [
 	"Natural Language :: English",
 	"Operating System :: OS Independent",
 	"Programming Language :: Python :: 3",
-	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3 :: Only",
 	"Topic :: Scientific/Engineering :: Bio-Informatics",
@@ -106,7 +105,7 @@ pythonpath = ["src"]
 
 [tool.black]
 line-length = 100
-target-version = ["py310", "py311"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
The pysb dependency (via indra) only ships an installable wheel at 1.17.0, which requires Python >= 3.11; all earlier pysb versions are sdist-only and fail to build. So a clean install is only possible on 3.11+. Revert the 3.10 additions: requires-python >=3.11,<3.12, drop the 3.10 CI job and classifier, black target py311, and README/CONTRIBUTING/CHANGELOG wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and context

The installable `pysb` 1.17.0 wheel requires Python 3.11 or newer, making Python 3.10 unsupported. The project was updated to target Python 3.11 exclusively and keep compatibility metadata, CI, formatting configuration, and documentation consistent.

## Changes

- Restricted supported Python versions to `>=3.11,<3.12`.
- Removed Python 3.10 from the CI test matrix and package classifiers.
- Configured Black to target `py311`.
- Updated the README badge and prerequisites.
- Updated Python version guidance in `CONTRIBUTING.md`.
- Documented the Python 3.10 removal and `pysb` dependency requirement in `CHANGELOG.md`.

## Tests

- No unit tests were added or modified.
- CI test coverage was narrowed to Python 3.11.

## Coding guidelines

- No coding guideline violations identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->