### PR TITLE
Unpin torch (>=2.3,<2.5); add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ First publicly packaged release, focused on publication readiness.
 - PyPI packaging metadata: trove `classifiers` and search `keywords`.
 
 ### Changed
-- Set the supported Python range to 3.10–3.11 (`requires-python = ">=3.10,<3.12"`).
+- Set the supported Python range to 3.11–3.12 (`requires-python = ">=3.11,<3.13"`).
+- Unpinned PyTorch from `2.0.1` to `>=2.3,<2.5`, which adds Python 3.12 support.
+  The upper cap is required because `torch>=2.5` pins `sympy==1.13.1`, conflicting
+  with `pysb`'s `sympy<1.12` (pulled in via `indra`); the same conflict blocks
+  Python 3.13 (which would need `torch>=2.5`).
 - Install `indra` from PyPI instead of a `git+` URL, so the package can be
   published to PyPI (no direct-URL dependencies remain).
 - Made `indra-cogex` an optional dependency: its imports are now guarded, so the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ development environment, the conventions we follow, and how to submit changes.
 
 ## Development setup
 
-Causomic targets Python 3.10–3.11 and depends on PyTorch 2.0.1 and Pyro. We
+Causomic targets Python 3.11–3.12 and depends on PyTorch (2.3+) and Pyro. We
 recommend a clean virtual environment.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Causomic
 
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11-blue.svg)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
 [![codecov](https://codecov.io/gh/Vitek-Lab/Causomic/branch/main/graph/badge.svg)](https://codecov.io/gh/Vitek-Lab/Causomic)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Development Status](https://img.shields.io/badge/status-development-orange.svg)](https://github.com/Vitek-Lab/Causomic)
@@ -72,8 +72,8 @@ The package is particularly useful for:
 ## Installation
 
 ### Prerequisites
-- Python 3.10 or 3.11
-- PyTorch 2.0.1
+- Python 3.11 or 3.12
+- PyTorch 2.3+ (< 2.5)
 - Pyro-PPL
 
 ### Install from source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.9.0"
 description = "Python code for causal modeling of proteomics data."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.11,<3.13"
 
 authors = [
 	{ name = "Devon Kohler", email = "kohler.d@northeastern.edu" },
@@ -40,8 +40,8 @@ classifiers = [
 	"Natural Language :: English",
 	"Operating System :: OS Independent",
 	"Programming Language :: Python :: 3",
-	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: 3 :: Only",
 	"Topic :: Scientific/Engineering :: Bio-Informatics",
 	"Topic :: Scientific/Engineering :: Mathematics",
@@ -51,7 +51,10 @@ dependencies = [
 	"networkx",
 	"pandas",
 	"pyro-ppl==1.8.5",
-	"torch==2.0.1",
+	# torch is capped <2.5: torch>=2.5 pins sympy==1.13.1, which conflicts with
+	# pysb's sympy<1.12 (pysb is pulled in transitively via indra). torch<2.5
+	# provides wheels through Python 3.12 (3.13 would need torch>=2.5).
+	"torch>=2.3,<2.5",
 	"numpy<2",
 	"scipy",
 	"scikit-learn",
@@ -106,7 +109,7 @@ pythonpath = ["src"]
 
 [tool.black]
 line-length = 100
-target-version = ["py310", "py311"]
+target-version = ["py311", "py312"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
torch==2.0.1 was the only thing pinning us to Python 3.11 (no 3.12 wheels). Unpin to torch>=2.3,<2.5, which provides 3.12 wheels and keeps numpy-2-capable torch. Extend supported Python to 3.11-3.12.

The <2.5 upper cap is forced by a transitive conflict: torch>=2.5 pins sympy==1.13.1, but pysb (via indra) requires sympy<1.12. This same conflict blocks Python 3.13 (which needs torch>=2.5), so 3.13 is not yet supportable.

Verified on Linux (resolution) and via full test runs on 3.11 and 3.12 (torch 2.4.1, numpy 1.26.4): 162 tests pass on both.