### PR TITLE
Fix/hillclimb flip cycle

### DIFF
--- a/src/causomic/graph_construction/prior_data_reconciliation.py
+++ b/src/causomic/graph_construction/prior_data_reconciliation.py
@@ -376,11 +376,13 @@ class SparseHillClimb(HillClimbSearch):
                 continue
             if (Y, X) in forbidden:
                 continue
-            # cycle check for flips
-            # if any(len(path) > 2 for path in nx.all_simple_paths(model, X, Y)):
-            #     continue
+            # Cycle check for the flip X->Y => Y->X. After removing X->Y, adding
+            # Y->X creates a cycle iff a directed path X~>Y still exists (X~>Y plus
+            # Y->X closes a loop), so we must test that direction. The previous
+            # check used has_path(Y, X), which let cycle-creating flips through and
+            # produced non-DAG search outputs.
             model.remove_edge(X, Y)
-            if nx.has_path(model, Y, X):
+            if nx.has_path(model, X, Y):
                 model.add_edge(X, Y)
                 continue
             model.add_edge(X, Y)

--- a/src/causomic/graph_construction/prior_data_reconciliation.py
+++ b/src/causomic/graph_construction/prior_data_reconciliation.py
@@ -768,6 +768,8 @@ def process_bootstrap(
     expert_knowledge: ExpertKnowledge,
     seed: int = 0,
     random_init: bool = False,
+    subsample_frac: float = 0.65,
+    replace: bool = True,
 ) -> Optional[DAG]:
     """
     Process single bootstrap sample for causal discovery with uncertainty quantification.
@@ -835,8 +837,9 @@ def process_bootstrap(
     logging.getLogger("pgmpy").setLevel(logging.WARNING)
 
     rng = np.random.RandomState(seed)
-    subsample_frac = 0.65  # try 0.5–0.8
-    resampled_data = data.sample(frac=subsample_frac, replace=True, random_state=rng)
+    # subsample_frac<1 with replace=True -> a bootstrap resample (consensus mode);
+    # subsample_frac=1 with replace=False -> the full data (best-of-restarts mode).
+    resampled_data = data.sample(frac=subsample_frac, replace=replace, random_state=rng)
 
     # Initialize the custom scoring function
     custom_score = score_fn(resampled_data, edge_priors=edge_priors, prior_strength=prior_strength)
@@ -1138,6 +1141,8 @@ def run_bootstrap(
     convert_to_probability: bool = True,
     use_source_counts: bool = False,
     random_init: bool = False,
+    subsample_frac: float = 0.65,
+    replace: bool = True,
     verbose: bool = True,
 ) -> list:
     """
@@ -1273,8 +1278,10 @@ def run_bootstrap(
             expert_knowledge,
             seed=i,
             random_init=random_init,
+            subsample_frac=subsample_frac,
+            replace=replace,
         )
-        for i in tqdm(range(n_bootstrap), desc="Hill Climb Bootstraps")
+        for i in tqdm(range(n_bootstrap), desc="Hill Climb runs")
     )
     # for _ in range(n_bootstrap):
     #     process_bootstrap(

--- a/src/causomic/network.py
+++ b/src/causomic/network.py
@@ -57,6 +57,7 @@ from causomic.graph_construction.prior_data_reconciliation import (
     BICGaussIndraPriors,
     SparseHillClimb,
     calculate_edge_probabilities,
+    prepare_indra_priors,
     run_bootstrap,
 )
 from causomic.graph_construction.repair import convert_to_y0_graph, process_failed_test
@@ -291,6 +292,58 @@ def consensus_dag(bootstrap_dags, indra_priors, lam=0.25, min_freq=0.5):
     return G
 
 
+def best_scoring_dag(dags, data, edge_priors, scoring_function, prior_strength):
+    """Select the single highest-scoring acyclic DAG from candidate runs.
+
+    Each candidate is scored by its total local score
+    (``sum_v scoring_function.local_score(v, parents_v)``) on the full ``data``.
+    This implements "best-of-restarts" selection: run the hill climb from many
+    random initializations and keep the run that reached the best-scoring local
+    optimum, rather than voting on individual edges across bootstrap resamples.
+
+    Parameters
+    ----------
+    dags : list of DAG or None
+        Candidate DAGs (e.g. the per-restart outputs of ``run_bootstrap``).
+    data : pd.DataFrame
+        Full observational data used to score every candidate on equal footing.
+    edge_priors : dict
+        {(parent, child): prior_probability} for the allowed edges.
+    scoring_function : type
+        Scoring class (e.g. ``BICGaussIndraPriors``); BIC penalizes complexity
+        more heavily than AIC and is the recommended choice here.
+    prior_strength : float
+        Passed through to the scoring function.
+
+    Returns
+    -------
+    (best_dag, scores) : tuple[nx.DiGraph, list[Optional[float]]]
+        ``best_dag`` is the top-scoring candidate (an empty DiGraph over the data
+        columns if none are valid); ``scores`` is the per-candidate total score
+        (``None`` for missing or cyclic runs), aligned with ``dags``.
+    """
+    scorer = scoring_function(data, edge_priors=edge_priors, prior_strength=prior_strength)
+    best, best_score, scores = None, -np.inf, []
+    for dag in dags:
+        if dag is None:
+            scores.append(None)
+            continue
+        G = nx.DiGraph()
+        G.add_nodes_from(data.columns)
+        G.add_edges_from(dag.edges())
+        if not nx.is_directed_acyclic_graph(G):
+            scores.append(None)
+            continue
+        s = float(sum(scorer.local_score(v, list(G.predecessors(v))) for v in data.columns))
+        scores.append(s)
+        if s > best_score:
+            best_score, best = s, dag
+    if best is None:
+        best = nx.DiGraph()
+        best.add_nodes_from(data.columns)
+    return best, scores
+
+
 def estimate_posterior_dag(
     data: pd.DataFrame,
     indra_priors: pd.DataFrame,
@@ -305,6 +358,8 @@ def estimate_posterior_dag(
     use_source_counts: bool = False,
     return_bootstrap_dags: bool = False,
     random_init: bool = False,
+    selection: str = "best_of",
+    return_runs: bool = False,
     verbose: bool = True,
 ) -> NxMixedGraph:
     """
@@ -447,8 +502,23 @@ def estimate_posterior_dag(
             + ", ".join(sorted(missing_nodes))
         )
 
-    # Prepare input arguments for bootstrap sampling
-    model_input = (
+    # ------------------------------------------------------------------
+    # Run the search many times, then reduce to a single posterior DAG.
+    #   selection="best_of"   -> n_bootstrap random-restart hill climbs on the
+    #                            FULL data; keep the highest-scoring acyclic DAG
+    #                            (use a BIC scoring_function to control false edges).
+    #   selection="consensus" -> bootstrap resamples + >=edge_probability edge vote
+    #                            (the original behaviour).
+    # ------------------------------------------------------------------
+    if selection == "best_of":
+        run_frac, run_replace, run_random_init = 1.0, False, True
+    elif selection == "consensus":
+        run_frac, run_replace, run_random_init = 0.65, True, random_init
+    else:
+        raise ValueError(f"Unknown selection={selection!r}; use 'best_of' or 'consensus'.")
+
+    # Run the search to generate multiple DAG hypotheses
+    bootstrap_dags = run_bootstrap(
         data,
         indra_priors,
         prior_strength,
@@ -460,20 +530,29 @@ def estimate_posterior_dag(
         n_bootstrap,
         convert_to_probability,
         use_source_counts,
-        random_init,
+        run_random_init,
+        subsample_frac=run_frac,
+        replace=run_replace,
+        verbose=verbose,
     )
 
-    # Run bootstrap sampling to generate multiple DAG hypotheses
-    bootstrap_dags = run_bootstrap(*model_input, verbose=verbose)
-
-    # Integrate bootstrap results into one final DAG using consensus approach
-    posterior_dag = consensus_dag(bootstrap_dags, indra_priors, lam=0.25, min_freq=edge_probability)
-    posterior_dag = pd.DataFrame(posterior_dag.edges, columns=["source", "target"])
+    # Reduce the runs to one posterior DAG
+    run_scores = None
+    if selection == "best_of":
+        edge_priors = prepare_indra_priors(indra_priors, convert_to_probability, use_source_counts)
+        best_dag, run_scores = best_scoring_dag(
+            bootstrap_dags, data, edge_priors, scoring_function, prior_strength
+        )
+        posterior_dag = pd.DataFrame(list(best_dag.edges()), columns=["source", "target"])
+    else:
+        cons = consensus_dag(bootstrap_dags, indra_priors, lam=0.25, min_freq=edge_probability)
+        posterior_dag = pd.DataFrame(list(cons.edges()), columns=["source", "target"])
 
     # Convert posterior DAG to y0 graph format
     y0_graph = convert_to_y0_graph(posterior_dag)
 
-    # Compute per-edge bootstrap frequencies and store as edge_prob attribute
+    # Per-edge frequency across runs, stored as edge_prob (bootstrap frequency for
+    # consensus; restart-stability for best_of).
     valid_dags = [d for d in bootstrap_dags if d is not None]
     total = len(valid_dags)
     edge_counts: Counter = Counter()
@@ -485,6 +564,8 @@ def estimate_posterior_dag(
             edge_counts[(str(u), str(v))] / total if total > 0 else 0.5
         )
 
+    if return_runs:
+        return y0_graph, bootstrap_dags, run_scores
     if return_bootstrap_dags:
         return y0_graph, bootstrap_dags
     return y0_graph


### PR DESCRIPTION
This pull request introduces significant improvements and new features to the causal discovery pipeline, focusing on more flexible and robust selection of posterior DAGs from multiple search runs. The main changes add support for both "best-of-restarts" and "consensus" selection modes, improve cycle checking logic, and enhance configurability of bootstrap sampling. Below are the most important changes grouped by theme:

**1. Selection Modes for Posterior DAG Construction**
- Added a new `selection` parameter to `estimate_posterior_dag` to choose between "best_of" (select the single highest-scoring acyclic DAG from multiple random-restart hill climbs) and "consensus" (edge voting across bootstrap resamples, the previous default). The "best_of" mode uses a new `best_scoring_dag` function and a BIC-based scoring function for robust model selection. (`[[1]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0R361-R362)`, `[[2]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0L450-R521)`, `[[3]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0L463-R555)`, `[[4]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0R295-R346)`)
- Added an optional `return_runs` parameter to return all candidate DAGs and their scores for further analysis. (`[[1]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0R361-R362)`, `[[2]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0R567-R568)`)

**2. Bootstrap Sampling and Random Restarts**
- Made subsample fraction (`subsample_frac`) and sampling with/without replacement (`replace`) configurable in both `process_bootstrap` and `run_bootstrap`, allowing for both true bootstrapping (sampling with replacement) and full-data random restarts. (`[[1]](diffhunk://#diff-754166c80cca0acbed688b9a2cd8493847df8c1036e63db41d6c53f06ddec633R771-R772)`, `[[2]](diffhunk://#diff-754166c80cca0acbed688b9a2cd8493847df8c1036e63db41d6c53f06ddec633L836-R842)`, `[[3]](diffhunk://#diff-754166c80cca0acbed688b9a2cd8493847df8c1036e63db41d6c53f06ddec633R1144-R1145)`, `[[4]](diffhunk://#diff-754166c80cca0acbed688b9a2cd8493847df8c1036e63db41d6c53f06ddec633R1281-R1284)`)
- Adjusted the bootstrap logic to use these parameters appropriately depending on the selected mode. (`[[1]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0L450-R521)`, `[[2]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0L463-R555)`)

**3. Cycle Checking Logic**
- Fixed a bug in the cycle check for edge flips in `_legal_operations` by ensuring that a flip only proceeds if adding the reversed edge does not create a cycle, using the correct direction for path checking. This prevents invalid (cyclic) DAGs from being produced. (`[src/causomic/graph_construction/prior_data_reconciliation.pyL379-R385](diffhunk://#diff-754166c80cca0acbed688b9a2cd8493847df8c1036e63db41d6c53f06ddec633L379-R385)`)

**4. API and Usability Enhancements**
- Added `prepare_indra_priors` to the imports in `network.py` to support the new selection logic. (`[src/causomic/network.pyR60](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0R60)`)
- Improved documentation and comments throughout the code to clarify the intent and usage of new parameters and selection logic. (`[[1]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0R295-R346)`, `[[2]](diffhunk://#diff-91fe8f60a8d9de7e333adff6b996f86389cc92943c60f8bb610226713cf12eb0R361-R362)`)

These changes make the pipeline more robust, configurable, and suitable for both consensus-based and best-of-restarts causal discovery workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and context

Causal discovery relied on bootstrap DAG consensus, but lacked a way to select the strongest candidate from full-data random restarts. Additionally, an incorrect cycle-check direction could allow edge flips that produced cyclic graphs, reducing bootstrap reliability. This PR adds configurable posterior DAG selection and resampling behavior, introduces BIC-based best-candidate selection, and fixes cycle-producing flips.

## Changes

- Added `best_of` and `consensus` selection modes to `estimate_posterior_dag`.
- Made `best_of` the default selection mode.
- Added `best_scoring_dag` to:
  - Score candidate DAGs on the full dataset.
  - Reject cyclic or invalid candidates.
  - Return the highest-scoring acyclic DAG and per-run scores.
  - Fall back to an empty DAG when no candidates are valid.
- Added optional `return_runs` output for candidate DAGs and scores.
- Preserved bootstrap edge-voting behavior for `selection="consensus"`.
- Added configurable `subsample_frac` and `replace` parameters to `process_bootstrap` and `run_bootstrap`.
- Added full-data random-restart behavior for best-of selection.
- Corrected edge-flip cycle detection in `SparseHillClimb._legal_operations`.
- Updated public imports and documentation for the new APIs.

## Unit tests

No test additions or modifications are identified in the provided change summary.

## Coding guideline violations

No coding guideline violations are identified in the provided change summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->