### PR TITLE
fixed node name bug

### DIFF
--- a/src/causomic/network.py
+++ b/src/causomic/network.py
@@ -583,8 +583,22 @@ def nodes_on_causal_paths(
     BFS passes.
     """
     directed = G.directed
-    start_nodes = set(start_nodes) & set(directed.nodes)
-    end_nodes = set(end_nodes) & set(directed.nodes)
+    # y0 stores nodes as Variable objects, but callers typically pass plain gene
+    # name strings. Match on the node's string name so either form resolves to the
+    # actual graph node (otherwise the set intersection is empty and the filter
+    # silently drops every node).
+    by_name = {getattr(n, "name", str(n)): n for n in directed.nodes}
+
+    def _resolve(names):
+        resolved = set()
+        for x in names:
+            key = getattr(x, "name", str(x))
+            if key in by_name:
+                resolved.add(by_name[key])
+        return resolved
+
+    start_nodes = _resolve(start_nodes)
+    end_nodes = _resolve(end_nodes)
 
     # Forward-reachable from any start node
     forward = set()


### PR DESCRIPTION
This pull request improves the robustness of node resolution in the `nodes_on_causal_paths` function in `src/causomic/network.py`. The main change ensures that both string names and `Variable` objects representing nodes are correctly matched and resolved, preventing issues where nodes are silently dropped due to mismatched types.

**Node resolution improvements:**

* Updated the logic for resolving `start_nodes` and `end_nodes` so that both string names and `Variable` objects are matched to the actual graph nodes by comparing their `name` attribute or string representation. This prevents nodes from being unintentionally dropped when their types differ.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

`nodes_on_causal_paths` could silently omit nodes when `start_nodes` or `end_nodes` were supplied as `Variable` objects rather than the graph’s exact node instances. The function now resolves inputs by node name or string representation before calculating causal-path reachability.

## Changes

- Updated `nodes_on_causal_paths` in `src/causomic/network.py`.
- Builds a lookup from graph node names, falling back to `str(node)`.
- Resolves string names and objects with a `.name` attribute to actual graph nodes.
- Prevents type or identity mismatches from producing empty start/end node sets.
- Preserves existing forward and backward reachability behavior.

## Unit Tests

No unit tests were added or modified.

## Coding Guidelines

No coding guideline violations were identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->