### PR TITLE
documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,44 @@ The end-to-end workflow follows three steps:
 simulated ground-truth system and a real INDRA network (EGFR inhibition),
 from graph construction through interventional inference. Start there.
 
+### Getting a prior network from INDRA
+
+Step 1 above needs an INDRA-derived graph to filter and query. There are two ways
+to get one:
+
+- **Local INDRA snapshot (recommended, offline).** Load a pre-cached INDRA
+  network — e.g. a `networkx.DiGraph` pickled from an INDRA CoGEx export — and
+  filter it with `prepare_graph`:
+
+  ```python
+  import pickle
+  from causomic.graph_construction import prepare_graph, query_forward_paths
+
+  with open("indranet_dir_graph_fix_corr_weights.pkl", "rb") as f:
+      indra_graph = pickle.load(f)
+
+  filtered_graph = prepare_graph(
+      indra_graph,
+      measured_nodes=None,          # or your list of measured gene symbols
+      node_types=["HGNC"],
+      stmt_types=["IncreaseAmount", "DecreaseAmount"],
+  )
+
+  prior_edges = query_forward_paths(
+      filtered_graph, start_nodes=["EGFR"], end_nodes=["ERK"], n_mediators=2,
+  )
+  ```
+
+  This is the pattern used throughout the lab's own projects and requires no
+  live database connection — only a local copy of the INDRA graph pickle.
+
+- **Live Neo4j query (alternative).** `extract_indra_prior` queries a running
+  INDRA CoGEx Neo4j instance directly and is useful if you need up-to-date
+  statements rather than a static snapshot. It requires the optional
+  [INDRA-CoGEx install](#optional-dependencies) and a reachable Neo4j database
+  with credentials (`Neo4jClient(url=..., auth=(...))`) — see its docstring
+  for the full query example.
+
 ## Data Requirements
 
 ### Input Data Format
@@ -135,6 +173,11 @@ network with experimental data.
 - `query_drug_targets`, `query_effect_nodes`, `query_forward_paths`, `query_confounders`
 - `prepare_indra_priors`, `run_bootstrap`, `calculate_edge_probabilities`
 
+  `query_forward_paths` is the built-in control for maximum path length /
+  mediator count between a source and target node — its `n_mediators`
+  argument caps how many intermediate nodes a path may have, so you don't
+  need to reimplement path-length pruning yourself.
+
 ### 🎯 **Causal Modeling** (`causomic.causal_model`)
 Probabilistic structural causal models for intervention prediction.
 - `LVM` — latent-variable model (fit / intervention interface)
@@ -153,12 +196,15 @@ Synthetic graph and data generation for testing and method development.
 - `generate_structured_dag`, `generate_indra_data`, `generate_cyclic_graph`
 
 ### 🚀 **High-Level Entry Points**
-- `causomic.network` — network estimation helpers (`extract_indra_prior`,
-  `consensus_dag`, `estimate_posterior_dag`, `filter_to_causal_subgraph`, …)
-- `causomic.workflows` — packaged pipelines (`run_toxicity_detection_workflow`)
+- `causomic.network` — network estimation helpers (`estimate_posterior_dag`,
+  `filter_to_causal_subgraph`, `repair_confounding`, `extract_indra_prior`, …)
+- `causomic.workflows` — packaged pipelines (`run_causal_workflow`,
+  `run_toxicity_detection_workflow`)
 
-  Some of these helpers query INDRA-CoGEx and require the optional
-  [INDRA-CoGEx install](#optional-dependencies).
+  `extract_indra_prior` queries INDRA-CoGEx live and requires the optional
+  [INDRA-CoGEx install](#optional-dependencies); most projects instead load a
+  local INDRA graph pickle and call `prepare_graph` directly (see
+  [Getting a prior network from INDRA](#getting-a-prior-network-from-indra)).
 
 ## Documentation
 

--- a/src/causomic/causal_model/LVM.py
+++ b/src/causomic/causal_model/LVM.py
@@ -113,6 +113,13 @@ class LVM:
         Minimum loss improvement to reset patience counter (Pyro only)
     informative_priors : dict, optional
         Dictionary specifying informative priors for model parameters
+    seed : int, default=1234
+        Random seed used to initialize inference (Pyro only, via
+        ``pyro.set_rng_seed``). Fitting the same data/graph with the same
+        seed is deterministic. To get run-to-run variation (e.g. for
+        bootstrap-style uncertainty estimates), either pass a different seed
+        or bootstrap/resample the input data between fits rather than
+        relying on inference randomness.
     verbose : bool, default=False
         Whether to print detailed progress information during model fitting
 
@@ -208,6 +215,7 @@ class LVM:
         patience: int = 75,
         min_delta: float = 50,
         informative_priors: Optional[Dict[str, Dict[str, float]]] = None,
+        seed: int = 1234,
         verbose: bool = False,
         stochastic_edges: bool = False,
     ):
@@ -227,6 +235,7 @@ class LVM:
         self.patience = patience
         self.min_delta = min_delta
         self.informative_priors = informative_priors
+        self.seed = seed
         self.verbose = verbose
         self.stochastic_edges = stochastic_edges
 
@@ -785,8 +794,8 @@ class LVM:
         if verbose is None:
             verbose = self.verbose
 
-        # Set random seed for reproducibility
-        pyro.set_rng_seed(1234)
+        # Set random seed for reproducibility (see LVM(seed=...) to override)
+        pyro.set_rng_seed(self.seed)
 
         # Initialize the model
         model_cls = (
@@ -1150,13 +1159,20 @@ class LVM:
         ----------
         intervention : Dict[str, float]
             Dictionary specifying the intervention. Keys are variable names
-            and values are the intervention levels.
+            and values are the intervention levels, given as ABSOLUTE/raw
+            target-scale values in the same units the model was fit on (e.g.
+            log2 abundance) — NOT deltas or fold-changes relative to baseline,
+            despite "intervention" reading as "the change to apply". The
+            model internally scales these values with the same
+            mean/std learned in ``fit``, so pass values on the original data
+            scale.
             Example: {"Treatment": 1.0} or {"Drug_A": 2.0, "Drug_B": 1.5}
         outcome_node : Union[str, List[str]]
             Name of the outcome variable or list of outcome variables to measure the intervention effect on
         compare_value : float, default=0.0
-            Baseline value for comparison (control condition)
-        predictive_samples : int, default=1000
+            Baseline value for comparison (control condition), also on the
+            absolute target scale (see ``intervention`` above).
+        predictive_samples : int, default=100
             Number of posterior samples to draw for estimating outcomes
 
         Sets
@@ -1188,6 +1204,21 @@ class LVM:
 
         >>> lvm.intervention({"Drug_A": 2.0, "Drug_B": 1.5}, "Survival")
         >>> effect_size = (lvm.intervention_samples - lvm.posterior_samples).mean()
+
+        Converting a fold-change to an absolute intervention value:
+
+        Since ``intervention`` and ``compare_value`` are absolute levels, a
+        measured fold-change must be converted to the model's scale first.
+        If the data (and therefore the fit) is in log2 space, a fold-change
+        multiplies on the natural scale but *adds* on the log2 scale:
+
+        >>> baseline_mean = float(observational_data["Treatment"].mean())
+        >>> fold_change = 2.0  # e.g. a 2x increase measured experimentally
+        >>> intervention_value = baseline_mean + np.log2(fold_change)
+        >>> lvm.intervention(
+        ...     {"Treatment": intervention_value}, "Outcome",
+        ...     compare_value=baseline_mean,
+        ... )
 
         Note
         ----

--- a/src/causomic/graph_construction/utils_nx.py
+++ b/src/causomic/graph_construction/utils_nx.py
@@ -114,7 +114,19 @@ def prepare_graph(
         node_types: Allowed node namespace types (e.g., ["HGNC"]). If
             omitted, all node namespaces are allowed.
         stmt_types: Allowed statement types to keep on edges. If omitted,
-            all statement types are allowed.
+            all statement types are allowed. This is matched verbatim against
+            whatever ``stmt_type`` string each raw INDRA statement dict carries
+            (see the ``"statements"`` edge attribute) — there is no fixed enum
+            or validation, so a typo silently drops all statements of that
+            type rather than raising. Common values seen in INDRA output
+            include "IncreaseAmount", "DecreaseAmount", "Activation",
+            "Inhibition", "Phosphorylation", and "Dephosphorylation". Amount
+            changes ("IncreaseAmount"/"DecreaseAmount") are the right choice
+            when the downstream readout is total protein abundance; include
+            the phospho-specific types ("Phosphorylation"/
+            "Dephosphorylation") as well when the readout is itself
+            phosphorylation data, since phospho-state changes are not
+            necessarily reflected in the amount-change statement types.
 
     Returns:
         A prepared :class:`networkx.DiGraph` suitable for path queries and
@@ -529,6 +541,12 @@ def query_forward_paths(
 ) -> pd.DataFrame:
     """Search for simple forward paths from any start node to any end node.
 
+    This is the built-in control for how far a path is allowed to travel
+    between a source and target node: ``n_mediators`` sets the maximum number
+    of intermediate nodes allowed on a source -> target path (path length =
+    ``n_mediators + 1`` edges). Use it instead of reimplementing path-length
+    pruning on top of the raw graph.
+
     For each mediator depth from 0..n_mediators the function will collect
     paths with exactly that many intermediate nodes between the start and
     end nodes. This corresponds to path lengths of ``mediator_count + 1``
@@ -543,12 +561,13 @@ def query_forward_paths(
         graph: DiGraph annotated with evidence counts on edges.
         start_nodes: Iterable of starting node ids.
         end_nodes: Iterable of target node ids.
-        n_mediators: Maximum number of mediator nodes between start and end.
-        med_ev_filter: Optional list of integer thresholds with length
+        n_mediators: Maximum number of intermediate nodes allowed on a
+            source -> target path (path length = n_mediators + 1 edges).
+        med_ev_filter: Per-depth evidence-count thresholds: a list of length
             ``n_mediators + 1`` where index ``i`` applies to paths with
             ``i`` mediators. If None, defaults to all ones.
-        med_src_filter: Optional list of integer source count thresholds with
-            length ``n_mediators + 1`` where index ``i`` applies to paths with
+        med_src_filter: Per-depth source-count thresholds: a list of length
+            ``n_mediators + 1`` where index ``i`` applies to paths with
             ``i`` mediators. If None, defaults to all ones.
 
     Returns:

--- a/src/causomic/workflows.py
+++ b/src/causomic/workflows.py
@@ -1,19 +1,27 @@
 """Workflow entrypoints for causomic network estimation pipelines.
 
-This module currently exposes the toxicity detection workflow and lightweight
-file logging utilities for tracking graph sizes across workflow steps.
+This module exposes two packaged pipelines plus lightweight file logging
+utilities for tracking graph sizes across workflow steps:
+
+- `run_toxicity_detection_workflow`: drug-name + DILI-target use case, resolves
+  target/outcome nodes via `query_drug_targets`/`query_effect_nodes`. Chains
+  `query_forward_paths` -> `estimate_posterior_dag` -> `repair_confounding`.
+- `run_causal_workflow`: generic counterpart for when target/outcome nodes are
+  already known gene symbols. Same call order, plus `LVM.fit`/
+  `LVM.intervention` appended, returning predicted vs. baseline outcome values.
 """
 
 import os
 import pickle
 from datetime import datetime
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import networkx as nx
 import numpy as np
 import pandas as pd
-from sklearn.model_selection import train_test_split
+from y0.graph import NxMixedGraph
 
+from causomic.causal_model import LVM
 from causomic.graph_construction.prior_data_reconciliation import (
     BICGaussIndraPriors,
     SparseHillClimb,
@@ -147,14 +155,25 @@ def run_toxicity_detection_workflow(
         Evidence thresholds per mediator level; defaults to [1, 1, 1, 2].
     log_file : str or None, default="graph_step_counts.log"
         Output path for workflow diagnostics log. Set to None to disable logging.
+
+    Notes
+    -----
+    The same full `input_data` is used both for DAG structure learning
+    (`estimate_posterior_dag`) and for the downstream data passed back to the
+    caller for model fitting — there is no train/test split. This is
+    intentional: `estimate_posterior_dag` already bootstraps over the data
+    internally to quantify structure-learning uncertainty, so holding out a
+    separate fitting split would only shrink the sample available to the
+    (typically data-hungry) causal model fit without buying additional
+    protection against overfitting the graph.
     """
     if mediator_evidence_count_threshold is None:
         mediator_evidence_count_threshold = [1, 1, 1, 2]
 
     measured_proteins = input_data.columns.tolist()
 
-    # Randomly split input_data into two equal parts
-    # input_data_graph, _ = train_test_split(input_data, test_size=0.5, random_state=42)
+    # Use the full dataset for both graph learning and the downstream fit
+    # (see "Notes" above for why this isn't split).
     input_data_graph = input_data.copy()
 
     # Extra drug targets
@@ -229,3 +248,196 @@ def run_toxicity_detection_workflow(
     _log_graph_step("repaired_network", repaired_network, log_file, drug_name=drug_name)
 
     return indra_prior, posterior_network, repaired_network
+
+
+def run_causal_workflow(
+    data: pd.DataFrame,
+    indra_graph: nx.DiGraph,
+    target_nodes: Sequence[str],
+    outcome_nodes: Sequence[str],
+    intervention: Dict[str, float],
+    evidence_count_threshold: int = 1,
+    number_of_mediators: int = 1,
+    mediator_evidence_count_threshold: Optional[Sequence[int]] = None,
+    mediator_source_count_threshold: Optional[Sequence[int]] = None,
+    prior_strength: float = 5.0,
+    n_bootstrap: int = 100,
+    corr_threshold: float = 0.5,
+    edge_probability: float = 0.5,
+    repair_confounders: bool = True,
+    max_conditional: int = 2,
+    confounder_evidence: int = 5,
+    lvm_backend: str = "pyro",
+    lvm_kwargs: Optional[Dict[str, Any]] = None,
+    compare_value: float = 0.0,
+    predictive_samples: int = 100,
+    log_file: Optional[str] = "graph_step_counts.log",
+) -> Tuple[pd.DataFrame, NxMixedGraph, NxMixedGraph, LVM, pd.DataFrame]:
+    """Chain prior extraction through interventional prediction for known nodes.
+
+    Generic counterpart to `run_toxicity_detection_workflow`: instead of
+    resolving targets/outcomes from a drug name and a DILI lookup via
+    `query_drug_targets`/`query_effect_nodes`, this function takes gene-symbol
+    node lists directly. It reuses the same call order as
+    `run_toxicity_detection_workflow` — `query_forward_paths` ->
+    `estimate_posterior_dag` -> `repair_confounding` — and appends
+    `LVM.fit` / `LVM.intervention`, returning predicted vs. baseline values
+    for the outcome nodes.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Wide-format proteomics data (genes as columns, samples as rows). The
+        full dataset is used for both graph learning and the downstream LVM
+        fit — see the "Notes" section of `run_toxicity_detection_workflow`
+        for why that's the intended behavior rather than an oversight.
+    indra_graph : nx.DiGraph
+        INDRA prior graph with edge evidence attributes (e.g. produced by
+        `causomic.graph_construction.prepare_graph`).
+    target_nodes : sequence of str
+        Known upstream gene symbols to use as `start_nodes` for
+        `query_forward_paths` and as the intervention target set.
+    outcome_nodes : sequence of str
+        Known downstream gene symbols to use as `end_nodes` for
+        `query_forward_paths` and as the outcome nodes for the final
+        `LVM.intervention` call.
+    intervention : dict[str, float]
+        Intervention values passed to `LVM.intervention`. These are ABSOLUTE
+        target-scale values in the same units as `data` (e.g. log2
+        abundance), not deltas or fold-changes — see `LVM.intervention` for
+        the fold-change conversion recipe.
+    evidence_count_threshold : int, default=1
+        Evidence threshold used to build a uniform
+        `mediator_evidence_count_threshold` when one isn't supplied.
+    number_of_mediators : int, default=1
+        Maximum number of mediators allowed between target and outcome nodes;
+        forwarded to `query_forward_paths` as `n_mediators`.
+    mediator_evidence_count_threshold, mediator_source_count_threshold : sequence of int, optional
+        Per-depth thresholds forwarded to `query_forward_paths` as
+        `med_ev_filter` / `med_src_filter`. Each defaults to a uniform list
+        of length `number_of_mediators + 1` (using `evidence_count_threshold`
+        and 1, respectively) when not supplied.
+    prior_strength, n_bootstrap, corr_threshold, edge_probability
+        Forwarded to `estimate_posterior_dag`.
+    repair_confounders : bool, default=True
+        Whether to run `repair_confounding` on the posterior DAG before
+        fitting. Set to False to skip straight from the posterior DAG to
+        model fitting (cheaper, but leaves unresolved latent confounding
+        exactly as `estimate_posterior_dag` found it).
+    max_conditional, confounder_evidence
+        Forwarded to `repair_confounding` (only used if `repair_confounders`
+        is True).
+    lvm_backend : str, default="pyro"
+        Backend passed to `LVM(backend=...)`. The "numpyro" backend's
+        intervention path is experimental (see `LVM`) and is not recommended
+        here.
+    lvm_kwargs : dict, optional
+        Additional keyword arguments forwarded to the `LVM` constructor
+        (e.g. `num_steps`, `seed`).
+    compare_value, predictive_samples
+        Forwarded to `LVM.intervention`.
+    log_file : str or None, default="graph_step_counts.log"
+        Output path for workflow diagnostics log. Set to None to disable.
+
+    Returns
+    -------
+    indra_prior : pd.DataFrame
+        Forward-path edges extracted from `indra_graph`.
+    posterior_network : NxMixedGraph
+        DAG estimated by `estimate_posterior_dag`.
+    fitted_network : NxMixedGraph
+        The DAG actually used to fit the LVM: equal to `posterior_network`
+        if `repair_confounders=False`, otherwise the `repair_confounding`
+        output.
+    lvm : LVM
+        The fitted latent-variable model.
+    outcome_summary : pd.DataFrame
+        Indexed by outcome node, with columns "baseline" and "intervention"
+        (predicted posterior means) and "effect" (their difference).
+    """
+    if mediator_evidence_count_threshold is None:
+        mediator_evidence_count_threshold = [evidence_count_threshold] * (number_of_mediators + 1)
+    if mediator_source_count_threshold is None:
+        mediator_source_count_threshold = [1] * (number_of_mediators + 1)
+
+    target_nodes = [str(t).replace("-", "") for t in target_nodes]
+    outcome_nodes = [str(o).replace("-", "") for o in outcome_nodes]
+
+    mapping = {node: node.replace("-", "") for node in indra_graph.nodes()}
+    indra_graph = nx.relabel_nodes(indra_graph, mapping)
+
+    input_data_graph = data.copy()
+    input_data_graph.columns = input_data_graph.columns.str.replace("-", "")
+
+    indra_prior = query_forward_paths(
+        graph=indra_graph,
+        start_nodes=target_nodes,
+        end_nodes=outcome_nodes,
+        n_mediators=number_of_mediators,
+        med_ev_filter=list(mediator_evidence_count_threshold),
+        med_src_filter=list(mediator_source_count_threshold),
+    )
+    _log_graph_step("indra_prior", indra_prior, log_file)
+
+    if indra_prior.empty:
+        raise ValueError(
+            "No INDRA paths found between target_nodes and outcome_nodes; "
+            "try raising number_of_mediators or lowering evidence_count_threshold."
+        )
+
+    indra_nodes = pd.unique(indra_prior[["source", "target"]].values.ravel())
+    input_data_graph = input_data_graph.loc[:, input_data_graph.columns.isin(indra_nodes)]
+
+    posterior_network = estimate_posterior_dag(
+        data=input_data_graph,
+        indra_priors=indra_prior,
+        prior_strength=prior_strength,
+        scoring_function=BICGaussIndraPriors,
+        search_algorithm=SparseHillClimb,
+        n_bootstrap=n_bootstrap,
+        add_high_corr_edges_to_priors=False,
+        corr_threshold=corr_threshold,
+        edge_probability=edge_probability,
+    )
+    _log_graph_step("posterior_network", posterior_network, log_file)
+
+    if repair_confounders:
+        fitted_network = repair_confounding(
+            input_data_graph,
+            posterior_network,
+            indra_graph,
+            max_conditional=max_conditional,
+            confounder_evidence=confounder_evidence,
+        )
+        _log_graph_step("repaired_network", fitted_network, log_file)
+    else:
+        fitted_network = posterior_network
+
+    # repair_confounding can introduce confounder nodes that aren't measured
+    # in `data`; reindexing adds them as all-NaN columns so LVM's model-based
+    # missing-data imputation handles them like any other partially-observed
+    # node instead of raising a KeyError during fitting.
+    fitted_nodes = {str(n) for n in fitted_network.directed.nodes()} | {
+        str(n) for n in fitted_network.undirected.nodes()
+    }
+    fit_data = input_data_graph.reindex(columns=sorted(fitted_nodes))
+
+    lvm = LVM(backend=lvm_backend, **(lvm_kwargs or {}))
+    lvm.fit(fit_data, fitted_network)
+
+    lvm.intervention(
+        intervention,
+        outcome_node=list(outcome_nodes),
+        compare_value=compare_value,
+        predictive_samples=predictive_samples,
+    )
+
+    outcome_summary = pd.DataFrame(
+        {
+            "baseline": lvm.posterior_samples.mean(),
+            "intervention": lvm.intervention_samples.mean(),
+        }
+    )
+    outcome_summary["effect"] = outcome_summary["intervention"] - outcome_summary["baseline"]
+
+    return indra_prior, posterior_network, fitted_network, lvm, outcome_summary


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

The documentation had gaps around obtaining INDRA prior networks, path-length semantics, intervention values, deterministic inference, and available workflow entry points. This update clarifies those concepts and adds a reusable causal workflow while making Pyro randomness configurable.

## Detailed Changes

- Added README guidance for:
  - Obtaining INDRA-derived graphs from cached pickles or live Neo4j.
  - `query_forward_paths` mediator limits.
  - Network and workflow entry points.
  - Optional INDRA-CoGEx installation requirements.
- Added configurable `seed` support to `LVM`, replacing the hard-coded Pyro seed.
- Clarified `LVM.intervention` documentation:
  - Inputs are absolute target-scale values.
  - Added fold-change conversion examples.
  - Updated the documented `predictive_samples` default to `100`.
- Expanded graph utility documentation for:
  - Verbatim `stmt_type` matching.
  - Statement-type examples.
  - `n_mediators` path semantics.
  - Mediator filtering behavior.
- Documented toxicity workflow behavior, including use of all input data without a train/test split.
- Added `run_causal_workflow`, which builds an INDRA prior, estimates a posterior DAG, optionally repairs confounding, fits an `LVM`, runs interventions, and returns causal outputs and outcome summaries.
- Added validation for requests with no INDRA paths.

## Unit Tests

No unit tests were added or modified.

## Coding Guidelines

No coding guideline violations were identified from the provided changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->