### PR TITLE
Add DAGMA as a graph-search baseline for estimate_posterior_dag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ dev = [
 	"black==25.9.0",
 	"isort==8.0.1",
 ]
+dagma = [
+	"dagma",
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/src/causomic/_optional.py
+++ b/src/causomic/_optional.py
@@ -26,6 +26,15 @@ def missing_cogex(*_args, **_kwargs):
     raise ImportError(COGEX_INSTALL_HINT)
 
 
-def missing_dagma(*_args, **_kwargs):
-    """Placeholder for dagma symbols; raises a helpful error when used."""
-    raise ImportError(DAGMA_INSTALL_HINT)
+class MissingDagmaLinear:
+    """Placeholder for ``dagma.linear.DagmaLinear``.
+
+    This is a real class (rather than a function, like :func:`missing_cogex`)
+    so that modules which subclass ``DagmaLinear`` at import time (to layer
+    extra behavior on top of it) can still be defined when the optional
+    ``dagma`` dependency isn't installed. The helpful error is only raised if
+    the class is actually instantiated.
+    """
+
+    def __init__(self, *_args, **_kwargs):
+        raise ImportError(DAGMA_INSTALL_HINT)

--- a/src/causomic/_optional.py
+++ b/src/causomic/_optional.py
@@ -13,7 +13,19 @@ COGEX_INSTALL_HINT = (
     "    pip install git+https://github.com/gyorilab/indra_cogex.git"
 )
 
+DAGMA_INSTALL_HINT = (
+    "This feature requires the optional 'dagma' dependency. Install it with:\n"
+    "    pip install causomic[dagma]\n"
+    "or directly with:\n"
+    "    pip install dagma"
+)
+
 
 def missing_cogex(*_args, **_kwargs):
     """Placeholder for indra-cogex symbols; raises a helpful error when used."""
     raise ImportError(COGEX_INSTALL_HINT)
+
+
+def missing_dagma(*_args, **_kwargs):
+    """Placeholder for dagma symbols; raises a helpful error when used."""
+    raise ImportError(DAGMA_INSTALL_HINT)

--- a/src/causomic/graph_construction/prior_data_reconciliation.py
+++ b/src/causomic/graph_construction/prior_data_reconciliation.py
@@ -1695,7 +1695,9 @@ def run_dagma(
         cleaned_priors = indra_priors.copy()
         cleaned_priors["source"] = cleaned_priors["source"].astype(str).str.replace("-", "")
         cleaned_priors["target"] = cleaned_priors["target"].astype(str).str.replace("-", "")
-        edge_priors = prepare_indra_priors(cleaned_priors, convert_to_probability, use_source_counts)
+        edge_priors = prepare_indra_priors(
+            cleaned_priors, convert_to_probability, use_source_counts
+        )
         belief, mask = _build_dagma_belief_matrix(node_order, edge_priors)
         penalty_weights = evidence_penalty(belief, mask, clip=evidence_clip, center=evidence_center)
 

--- a/src/causomic/graph_construction/prior_data_reconciliation.py
+++ b/src/causomic/graph_construction/prior_data_reconciliation.py
@@ -81,7 +81,7 @@ try:
     from dagma.linear import DagmaLinear
     from scipy.special import expit as sigmoid
 except ImportError:  # optional dependency, see causomic._optional
-    from causomic._optional import missing_dagma as DagmaLinear
+    from causomic._optional import MissingDagmaLinear as DagmaLinear
 
 
 class SparseHillClimb(HillClimbSearch):

--- a/src/causomic/graph_construction/prior_data_reconciliation.py
+++ b/src/causomic/graph_construction/prior_data_reconciliation.py
@@ -76,6 +76,13 @@ from pgmpy.estimators.StructureScore import get_scoring_method
 from tqdm import tqdm
 from tqdm.auto import trange
 
+try:
+    import scipy.linalg as sla
+    from dagma.linear import DagmaLinear
+    from scipy.special import expit as sigmoid
+except ImportError:  # optional dependency, see causomic._optional
+    from causomic._optional import missing_dagma as DagmaLinear
+
 
 class SparseHillClimb(HillClimbSearch):
     """
@@ -1294,3 +1301,441 @@ def run_bootstrap(
     #     )
 
     return bootstrap_dags
+
+
+def _build_dagma_exclude_edges(
+    node_order: list, allowed_edges: Set[Tuple[str, str]]
+) -> Tuple[Tuple[int, int], ...]:
+    """Build a hard edge blacklist for ``DagmaLinear.fit``'s ``exclude_edges``.
+
+    Every ordered pair of distinct nodes in ``node_order`` that is not present
+    in ``allowed_edges`` is blacklisted, mirroring how
+    ``SparseHillClimb.allowed_additions`` restricts edge additions to the
+    INDRA prior network during hill climbing.
+
+    Parameters
+    ----------
+    node_order : list
+        Node names in the same order as the columns of the data matrix
+        passed to ``DagmaLinear.fit``. Blacklist indices are positional.
+    allowed_edges : set of (str, str)
+        (parent, child) pairs that are allowed to appear in the learned DAG.
+
+    Returns
+    -------
+    tuple of (int, int)
+        Row/column index pairs to exclude, in the same (parent, child)
+        convention as the estimated weight matrix ``W`` (``W[i, j]`` is the
+        edge from node ``i`` to node ``j``). ``DagmaLinear.fit`` requires an
+        actual ``tuple`` here -- a ``list`` fails its internal type check and
+        is silently ignored, so the return type is load-bearing.
+    """
+    index = {node: i for i, node in enumerate(node_order)}
+    return tuple(
+        (index[u], index[v])
+        for u in node_order
+        for v in node_order
+        if u != v and (u, v) not in allowed_edges
+    )
+
+
+def evidence_penalty(
+    belief: np.ndarray, mask: np.ndarray, clip: float = 3.0, center: bool = False
+) -> np.ndarray:
+    """Per-edge L1 penalty multiplier from INDRA evidence log-odds.
+
+    Edges with belief > 0.5 (net positive evidence) get a multiplier < 1,
+    lowering their effective L1 penalty in ``DagmaLinear``'s loss (more
+    likely to survive thresholding); edges with belief < 0.5 get a
+    multiplier > 1 (more discouraged). Only positions where ``mask`` is
+    True are reweighted; everywhere else the multiplier is 1.0 (DAGMA's
+    unweighted default).
+
+    Parameters
+    ----------
+    belief : np.ndarray
+        (d, d) matrix of prior edge probabilities in [0, 1].
+    mask : np.ndarray
+        (d, d) boolean matrix marking which positions have real prior
+        evidence (as opposed to a filler default value in ``belief``).
+    clip : float, default=3.0
+        Bounds the log-odds before exponentiating, so a single very
+        strong/weak prior can't drive the multiplier to 0 or blow it up.
+    center : bool, default=False
+        If True, subtract the mean log-odds (over masked entries) before
+        exponentiating, so the penalty is relative to the average prior
+        strength in this graph rather than to p=0.5.
+
+    Returns
+    -------
+    np.ndarray
+        (d, d) multiplier matrix; DAGMA's per-edge L1 penalty becomes
+        ``lambda1 * multiplier`` (elementwise).
+
+    Raises
+    ------
+    ValueError
+        If any ``belief[mask]`` value falls outside [0, 1]. Silently clipping
+        out-of-range values (e.g. raw evidence counts left un-converted by
+        ``prepare_indra_priors(..., convert_to_probability=False)``) would
+        collapse every evidenced edge to the same maximal log-odds -- a
+        uniform, not per-edge, discount -- without ever raising an error.
+    """
+    m = mask.astype(bool)
+    raw = belief[m]
+    if raw.size and ((raw < 0) | (raw > 1)).any():
+        bad = np.unique(raw[(raw < 0) | (raw > 1)])[:5]
+        raise ValueError(
+            "evidence_penalty expected belief[mask] to be probabilities in "
+            f"[0, 1], but found values outside that range (e.g. {bad.tolist()}). "
+            "This usually means raw evidence counts (or some other unconverted "
+            "quantity) were passed as `belief` -- convert them to probabilities "
+            "first, e.g. via prepare_indra_priors(..., convert_to_probability=True)."
+        )
+    p = np.clip(raw, 1e-6, 1 - 1e-6)
+    ell = np.log(p / (1 - p))
+    if center:
+        ell = ell - ell.mean()
+    C = np.ones_like(belief)
+    C[m] = np.exp(np.clip(-ell, -clip, clip))
+    return C
+
+
+def _build_dagma_belief_matrix(
+    node_order: list, edge_priors: dict, default_belief: float = 0.5
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Build the (belief, mask) matrices ``evidence_penalty`` expects.
+
+    Parameters
+    ----------
+    node_order : list
+        Node names in the same order as the DAGMA data columns.
+    edge_priors : dict
+        {(parent, child): probability} as returned by ``prepare_indra_priors``.
+    default_belief : float, default=0.5
+        Filler value for positions with no prior evidence (masked out, so
+        this value never actually affects the penalty).
+
+    Returns
+    -------
+    (np.ndarray, np.ndarray)
+        ``belief`` -- (d, d) prior probabilities, ``mask`` -- (d, d) boolean
+        array marking which positions came from ``edge_priors``.
+    """
+    d = len(node_order)
+    index = {node: i for i, node in enumerate(node_order)}
+    belief = np.full((d, d), default_belief, dtype=float)
+    mask = np.zeros((d, d), dtype=bool)
+    for (u, v), p in edge_priors.items():
+        i, j = index.get(u), index.get(v)
+        if i is None or j is None or i == j:
+            continue
+        belief[i, j] = p
+        mask[i, j] = True
+    return belief, mask
+
+
+class _EvidenceWeightedDagmaLinear(DagmaLinear):
+    """``DagmaLinear`` with a per-edge L1 penalty multiplier from INDRA evidence.
+
+    ``DagmaLinear`` (dagma==1.1.1) applies its L1 penalty as a scalar
+    subgradient term (``lambda1 * sign(W)``) inline inside ``minimize``, with
+    no public hook to vary it per edge. This subclass duplicates
+    ``minimize``/``_func`` from that version, replacing the scalar
+    ``lambda1`` term with an elementwise product against ``penalty_weights``
+    (see ``evidence_penalty``) wherever it appears, so edges with strong
+    INDRA evidence face a smaller effective penalty and edges with weak/no
+    evidence face a larger one. Everything else (Adam updates, the
+    include/exclude masks, the M-matrix domain checks) is unchanged from the
+    parent class.
+
+    Set ``penalty_weights`` (a (d, d) array, or ``None``) before calling
+    ``fit()``; ``None`` (the default set in ``__init__``) reproduces vanilla
+    ``DagmaLinear`` behavior.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.penalty_weights = None
+
+    def _func(
+        self, W: np.ndarray, mu: float, s: float = 1.0
+    ) -> Tuple[float, np.ndarray, np.ndarray]:
+        weights = 1.0 if self.penalty_weights is None else self.penalty_weights
+        score, _ = self._score(W)
+        h, _ = self._h(W, s)
+        obj = mu * (score + self.lambda1 * (weights * np.abs(W)).sum()) + h
+        return obj, score, h
+
+    def minimize(
+        self,
+        W: np.ndarray,
+        mu: float,
+        max_iter: int,
+        s: float,
+        lr: float,
+        tol: float = 1e-6,
+        beta_1: float = 0.99,
+        beta_2: float = 0.999,
+        pbar: Optional[Any] = None,
+    ) -> Tuple[np.ndarray, bool]:
+        weights = 1.0 if self.penalty_weights is None else self.penalty_weights
+
+        obj_prev = 1e16
+        self.opt_m, self.opt_v = 0, 0
+        self.vprint(
+            f"\n\nMinimize with -- mu:{mu} -- lr: {lr} -- s: {s} -- "
+            f"l1: {self.lambda1} for {max_iter} max iterations"
+        )
+        mask_inc = np.zeros((self.d, self.d))
+        if self.inc_c is not None:
+            mask_inc[self.inc_r, self.inc_c] = -2 * mu * self.lambda1
+        mask_exc = np.ones((self.d, self.d), dtype=self.dtype)
+        if self.exc_c is not None:
+            mask_exc[self.exc_r, self.exc_c] = 0.0
+
+        for iter in range(1, max_iter + 1):
+            # Compute the (sub)gradient of the objective
+            M = sla.inv(s * self.Id - W * W) + 1e-16
+            while np.any(M < 0):  # sI - W o W is not an M-matrix
+                if iter == 1 or s <= 0.9:
+                    self.vprint(f"W went out of domain for s={s} at iteration {iter}")
+                    return W, False
+                else:
+                    W += lr * grad
+                    lr *= 0.5
+                    if lr <= 1e-16:
+                        return W, True
+                    W -= lr * grad
+                    M = sla.inv(s * self.Id - W * W) + 1e-16
+                    self.vprint(f"Learning rate decreased to lr: {lr}")
+
+            if self.loss_type == "l2":
+                G_score = -mu * self.cov @ (self.Id - W)
+            elif self.loss_type == "logistic":
+                G_score = mu / self.n * self.X.T @ sigmoid(self.X @ W) - mu * self.cov
+
+            Gobj = (
+                G_score
+                + mu * self.lambda1 * weights * np.sign(W)
+                + 2 * W * M.T
+                + mask_inc * np.sign(W)
+            )
+
+            # Adam step
+            grad = self._adam_update(Gobj, iter, beta_1, beta_2)
+            W -= lr * grad
+            W *= mask_exc
+
+            # Check obj convergence
+            if iter % self.checkpoint == 0 or iter == max_iter:
+                obj_new, score, h = self._func(W, mu, s)
+                self.vprint(f"\nInner iteration {iter}")
+                self.vprint(f"\th(W_est): {h:.4e}")
+                self.vprint(f"\tscore(W_est): {score:.4e}")
+                self.vprint(f"\tobj(W_est): {obj_new:.4e}")
+                if np.abs((obj_prev - obj_new) / obj_prev) <= tol:
+                    pbar.update(max_iter - iter + 1)
+                    break
+                obj_prev = obj_new
+            pbar.update(1)
+        return W, True
+
+
+def _refit_unpenalized_ols(X: np.ndarray, dag: nx.DiGraph, node_order: list) -> None:
+    """Replace DAGMA's (penalized, shrunk) edge weights with unbiased OLS coefficients.
+
+    DAGMA's L1 penalty -- and, when ``use_evidence_weights`` is set, the
+    per-edge evidence multiplier on top of it -- shrinks every surviving
+    coefficient by a different amount depending on its prior strength. That
+    heterogeneous shrinkage means the raw penalized weight magnitude isn't
+    comparable across edges, which is fine for *selecting* the support (that's
+    ``w_threshold``'s job, already applied by the time this runs) but wrong
+    for *reporting* edge strength. This refits each node's parents with plain
+    OLS on the already-selected support -- unbiased, comparable magnitudes,
+    with no further change to which edges are in ``dag``.
+
+    Mutates ``dag`` in place, adding a ``weight`` attribute (the signed OLS
+    coefficient) to every edge.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        The same (already centered) data matrix passed to ``DagmaLinear.fit``.
+    dag : nx.DiGraph
+        The thresholded DAGMA graph; nodes must be a subset of ``node_order``.
+    node_order : list
+        Node names in the same order as ``X``'s columns.
+    """
+    index = {node: i for i, node in enumerate(node_order)}
+    for node in dag.nodes():
+        parents = list(dag.predecessors(node))
+        if not parents:
+            continue
+        child_col = X[:, index[node]]
+        parent_cols = X[:, [index[p] for p in parents]]
+        coefs, *_ = np.linalg.lstsq(parent_cols, child_col, rcond=None)
+        for parent, coef in zip(parents, coefs):
+            dag[parent][node]["weight"] = float(coef)
+
+
+def run_dagma(
+    data: pd.DataFrame,
+    indra_priors: pd.DataFrame,
+    lambda1: float = 0.02,
+    w_threshold: float = 0.2,
+    loss_type: str = "l2",
+    use_evidence_weights: bool = False,
+    convert_to_probability: bool = True,
+    use_source_counts: bool = False,
+    evidence_clip: float = 3.0,
+    evidence_center: bool = False,
+    dagma_fit_kwargs: Optional[dict] = None,
+    verbose: bool = False,
+) -> nx.DiGraph:
+    """Learn a DAG with DAGMA, restricted to edges present in the INDRA prior.
+
+    This is a continuous-optimization baseline alternative to
+    ``SparseHillClimb``: instead of a discrete hill-climb search, DAGMA
+    (Bello et al., 2022) solves a differentiable acyclicity-constrained
+    optimization over the full data in one shot. Edges outside the INDRA
+    prior network are hard-blacklisted via ``exclude_edges``, the same
+    "only allow prior edges" restriction that ``SparseHillClimb`` enforces
+    with ``allowed_additions``.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Observational data; columns are variables.
+    indra_priors : pd.DataFrame
+        Prior network with 'source'/'target' columns; only these edges
+        (after stripping hyphens, matching the rest of this module) are
+        allowed in the learned DAG.
+    lambda1 : float, default=0.02
+        L1 sparsity penalty passed to ``DagmaLinear.fit``.
+    w_threshold : float, default=0.2
+        Post-hoc weight threshold; entries of the estimated weighted
+        adjacency matrix with magnitude below this are zeroed out.
+    loss_type : str, default="l2"
+        Loss type passed to ``DagmaLinear`` (see the dagma package docs).
+    use_evidence_weights : bool, default=False
+        If True, additionally scale the L1 penalty per allowed edge by its
+        INDRA evidence strength (see ``evidence_penalty``): edges with
+        strong evidence (probability > 0.5) get a smaller effective
+        penalty, edges with weak evidence get a larger one. If False, all
+        allowed edges share the same ``lambda1`` (the hard prior blacklist
+        is unaffected either way).
+    convert_to_probability : bool, default=True
+        Passed to ``prepare_indra_priors`` when building evidence weights.
+    use_source_counts : bool, default=False
+        Passed to ``prepare_indra_priors`` when building evidence weights.
+    evidence_clip : float, default=3.0
+        Passed to ``evidence_penalty`` as ``clip``.
+    evidence_center : bool, default=False
+        Passed to ``evidence_penalty`` as ``center``.
+    dagma_fit_kwargs : dict, optional
+        Extra keyword arguments forwarded to ``DagmaLinear.fit`` -- most
+        usefully its convergence schedule (``T``, ``warm_iter``, ``max_iter``,
+        ``mu_init``, ``mu_factor``, ``s``, ``lr``, ...). DAGMA's defaults
+        (T=5, warm_iter=3e4, max_iter=6e4) assume a per-iteration cost that
+        stays cheap; each iteration does a dense (d, d) matrix inversion
+        (``d`` = number of columns in ``data``), so wall-clock time scales
+        with ``d`` regardless of how few edges the INDRA prior allows. For
+        graphs of a few hundred nodes or more, a lighter schedule (e.g.
+        ``{"T": 3, "warm_iter": 3000, "max_iter": 6000}``) is often necessary
+        to keep runtime reasonable. Must not set ``lambda1``, ``w_threshold``,
+        or ``exclude_edges`` (already supplied by this function's own
+        arguments). Default is None (use ``DagmaLinear.fit``'s own defaults).
+    verbose : bool, default=False
+        Passed through to ``DagmaLinear``.
+
+    Returns
+    -------
+    nx.DiGraph
+        Learned DAG over ``data.columns``, containing only edges allowed by
+        ``indra_priors``. DAGMA's acyclicity constraint only holds exactly in
+        the limit of the augmented-Lagrangian's central path (as ``T`` -> inf);
+        at a finite ``T`` the raw weighted matrix can retain a residual cycle,
+        which thresholding cannot introduce but also cannot guarantee away.
+        This function raises ``ValueError`` if the thresholded result is not
+        a DAG, rather than silently returning a cyclic graph. Each edge's
+        ``weight`` attribute is a refit, unpenalized OLS coefficient (see
+        ``_refit_unpenalized_ols``), not DAGMA's raw penalized weight -- the
+        penalized weight only decided *which* edges survive ``w_threshold``;
+        it's a biased (shrunk) estimate of their strength, especially with
+        ``use_evidence_weights=True`` where the shrinkage varies per edge.
+
+    Notes
+    -----
+    ``DagmaLinear`` represents the learned graph as a weighted adjacency
+    matrix ``W`` where ``W[i, j] != 0`` means an edge from node ``i``
+    (parent) to node ``j`` (child) -- verified empirically against a
+    synthetic linear SCM with a known effect direction.
+    """
+    node_order = list(data.columns)
+
+    allowed_edges = {
+        (
+            str(indra_priors.loc[i, "source"]).replace("-", ""),
+            str(indra_priors.loc[i, "target"]).replace("-", ""),
+        )
+        for i in range(len(indra_priors))
+    }
+
+    exclude_edges = _build_dagma_exclude_edges(node_order, allowed_edges) or None
+
+    if verbose:
+        print(
+            f"INFO: Running DAGMA on {len(node_order)} nodes with "
+            f"{len(allowed_edges)} allowed edges (lambda1={lambda1}, "
+            f"w_threshold={w_threshold}, use_evidence_weights={use_evidence_weights})."
+        )
+
+    if use_evidence_weights:
+        cleaned_priors = indra_priors.copy()
+        cleaned_priors["source"] = cleaned_priors["source"].astype(str).str.replace("-", "")
+        cleaned_priors["target"] = cleaned_priors["target"].astype(str).str.replace("-", "")
+        edge_priors = prepare_indra_priors(cleaned_priors, convert_to_probability, use_source_counts)
+        belief, mask = _build_dagma_belief_matrix(node_order, edge_priors)
+        penalty_weights = evidence_penalty(belief, mask, clip=evidence_clip, center=evidence_center)
+
+        dagma_model = _EvidenceWeightedDagmaLinear(loss_type=loss_type, verbose=False)
+        dagma_model.penalty_weights = penalty_weights
+    else:
+        dagma_model = DagmaLinear(loss_type=loss_type, verbose=False)
+
+    # DagmaLinear.fit centers internally for loss_type="l2", but it does so by
+    # mutating whatever array it's given in place -- which, via pandas'
+    # .values, leaks back into (and silently zero-means) the caller's own
+    # DataFrame. Centering explicitly here, into a fresh array, avoids both
+    # that side effect and any dependence on dagma's internal behavior.
+    X = data.values
+    X = X - X.mean(axis=0, keepdims=True)
+
+    W_est = dagma_model.fit(
+        X,
+        lambda1=lambda1,
+        w_threshold=w_threshold,
+        exclude_edges=exclude_edges,
+        **(dagma_fit_kwargs or {}),
+    )
+
+    dag = nx.DiGraph()
+    dag.add_nodes_from(node_order)
+    d = len(node_order)
+    for i in range(d):
+        for j in range(d):
+            if W_est[i, j] != 0:
+                dag.add_edge(node_order[i], node_order[j])
+
+    if not nx.is_directed_acyclic_graph(dag):
+        raise ValueError(
+            "DAGMA returned a graph with a cycle after thresholding at w_threshold="
+            f"{w_threshold}. This means the fit hadn't converged onto the acyclic "
+            "manifold (h(W) not ~0) at the configured schedule -- try a larger T "
+            "(and/or warm_iter/max_iter) via dagma_fit_kwargs."
+        )
+
+    _refit_unpenalized_ols(X, dag, node_order)
+
+    return dag

--- a/src/causomic/network.py
+++ b/src/causomic/network.py
@@ -29,7 +29,7 @@ Dependencies:
 import copy
 import os
 from collections import Counter
-from typing import Iterable, Set
+from typing import Iterable, Optional, Set
 
 import networkx as nx
 import numpy as np
@@ -59,6 +59,7 @@ from causomic.graph_construction.prior_data_reconciliation import (
     calculate_edge_probabilities,
     prepare_indra_priors,
     run_bootstrap,
+    run_dagma,
 )
 from causomic.graph_construction.repair import convert_to_y0_graph, process_failed_test
 from causomic.graph_construction.utils_neo4j import (
@@ -359,6 +360,12 @@ def estimate_posterior_dag(
     return_bootstrap_dags: bool = False,
     random_init: bool = False,
     selection: str = "best_of",
+    dagma_lambda1: float = 0.02,
+    dagma_w_threshold: float = 0.2,
+    dagma_loss_type: str = "l2",
+    dagma_evidence_clip: float = 3.0,
+    dagma_evidence_center: bool = False,
+    dagma_fit_kwargs: Optional[dict] = None,
     return_runs: bool = False,
     verbose: bool = True,
 ) -> NxMixedGraph:
@@ -423,6 +430,62 @@ def estimate_posterior_dag(
         If True, initialize each bootstrap hill climb from a random acyclic subgraph
         rather than an empty DAG. This can help escape local optima at the cost of
         increased run-to-run variability. Default is False.
+
+    selection : str, optional
+        How to reduce candidate DAGs to a single posterior DAG. One of:
+        - "best_of": n_bootstrap random-restart hill climbs on the full data;
+          keep the highest-scoring acyclic DAG (uses scoring_function/search_algorithm).
+        - "consensus": bootstrap resamples + >=edge_probability edge vote
+          (uses scoring_function/search_algorithm).
+        - "dagma": a single DAGMA continuous-optimization fit on the full data,
+          hard-restricted to edges present in indra_priors (see dagma_lambda1,
+          dagma_w_threshold, dagma_loss_type). scoring_function, search_algorithm,
+          n_bootstrap, edge_probability, and random_init are ignored in this mode;
+          edge_prob is set to 1.0 for every returned edge.
+        - "dagma_weighted": same as "dagma", but additionally scales the L1
+          penalty per allowed edge by its INDRA evidence log-odds (see
+          dagma_evidence_clip, dagma_evidence_center): edges with strong
+          evidence face a smaller effective penalty, weak-evidence edges a
+          larger one. This is the DAGMA analogue of how BICGaussIndraPriors
+          combines a hard allowed-edge restriction with a soft log-odds bonus
+          for SparseHillClimb.
+        Default is "best_of".
+
+    dagma_lambda1 : float, optional
+        L1 sparsity penalty for DAGMA's structural loss. Only used when
+        selection is "dagma" or "dagma_weighted". Default is 0.02.
+
+    dagma_w_threshold : float, optional
+        Post-hoc weight threshold for DAGMA's estimated adjacency matrix; entries
+        with magnitude below this are zeroed out. Only used when selection is
+        "dagma" or "dagma_weighted". Default is 0.2.
+
+    dagma_loss_type : str, optional
+        Loss type passed to DAGMA's DagmaLinear estimator. Only used when
+        selection is "dagma" or "dagma_weighted". Default is "l2".
+
+    dagma_evidence_clip : float, optional
+        Bounds the per-edge evidence log-odds before exponentiating into a
+        penalty multiplier, so a single very strong/weak prior can't dominate.
+        Only used when selection="dagma_weighted". Default is 3.0.
+
+    dagma_evidence_center : bool, optional
+        If True, center the per-edge log-odds by their mean (over prior-covered
+        edges) before computing the penalty multiplier, so the penalty is
+        relative to the average prior strength in this graph rather than to
+        p=0.5. Only used when selection="dagma_weighted". Default is False.
+
+    dagma_fit_kwargs : dict, optional
+        Extra keyword arguments forwarded to DAGMA's DagmaLinear.fit, most
+        usefully its convergence schedule (T, warm_iter, max_iter, mu_init,
+        mu_factor, s, lr, ...). DAGMA's defaults (T=5, warm_iter=3e4,
+        max_iter=6e4) assume a cheap per-iteration cost, but each iteration
+        does a dense (d, d) matrix inversion, so wall-clock time scales with
+        the number of data columns regardless of how few edges the INDRA
+        prior allows. For graphs of a few hundred nodes or more, a lighter
+        schedule (e.g. {"T": 3, "warm_iter": 3000, "max_iter": 6000}) is
+        often necessary. Only used when selection is "dagma" or
+        "dagma_weighted". Default is None (DagmaLinear.fit's own defaults).
 
     Returns
     -------
@@ -509,44 +572,71 @@ def estimate_posterior_dag(
     #                            (use a BIC scoring_function to control false edges).
     #   selection="consensus" -> bootstrap resamples + >=edge_probability edge vote
     #                            (the original behaviour).
+    #   selection="dagma"     -> a single DAGMA continuous-optimization fit on the
+    #                            full data, hard-restricted to indra_priors edges.
+    #   selection="dagma_weighted" -> same as "dagma", plus a per-edge L1 penalty
+    #                            scaled by INDRA evidence log-odds.
     # ------------------------------------------------------------------
-    if selection == "best_of":
-        run_frac, run_replace, run_random_init = 1.0, False, True
-    elif selection == "consensus":
-        run_frac, run_replace, run_random_init = 0.65, True, random_init
-    else:
-        raise ValueError(f"Unknown selection={selection!r}; use 'best_of' or 'consensus'.")
-
-    # Run the search to generate multiple DAG hypotheses
-    bootstrap_dags = run_bootstrap(
-        data,
-        indra_priors,
-        prior_strength,
-        scoring_function,
-        search_algorithm,
-        expert_knowledge,
-        add_high_corr_edges_to_priors,
-        corr_threshold,
-        n_bootstrap,
-        convert_to_probability,
-        use_source_counts,
-        run_random_init,
-        subsample_frac=run_frac,
-        replace=run_replace,
-        verbose=verbose,
-    )
-
-    # Reduce the runs to one posterior DAG
     run_scores = None
-    if selection == "best_of":
-        edge_priors = prepare_indra_priors(indra_priors, convert_to_probability, use_source_counts)
-        best_dag, run_scores = best_scoring_dag(
-            bootstrap_dags, data, edge_priors, scoring_function, prior_strength
+    if selection in ("dagma", "dagma_weighted"):
+        dagma_dag = run_dagma(
+            data,
+            indra_priors,
+            lambda1=dagma_lambda1,
+            w_threshold=dagma_w_threshold,
+            loss_type=dagma_loss_type,
+            use_evidence_weights=(selection == "dagma_weighted"),
+            convert_to_probability=convert_to_probability,
+            use_source_counts=use_source_counts,
+            evidence_clip=dagma_evidence_clip,
+            evidence_center=dagma_evidence_center,
+            dagma_fit_kwargs=dagma_fit_kwargs,
+            verbose=verbose,
         )
-        posterior_dag = pd.DataFrame(list(best_dag.edges()), columns=["source", "target"])
+        bootstrap_dags = [dagma_dag]
+        posterior_dag = pd.DataFrame(list(dagma_dag.edges()), columns=["source", "target"])
     else:
-        cons = consensus_dag(bootstrap_dags, indra_priors, lam=0.25, min_freq=edge_probability)
-        posterior_dag = pd.DataFrame(list(cons.edges()), columns=["source", "target"])
+        if selection == "best_of":
+            run_frac, run_replace, run_random_init = 1.0, False, True
+        elif selection == "consensus":
+            run_frac, run_replace, run_random_init = 0.65, True, random_init
+        else:
+            raise ValueError(
+                f"Unknown selection={selection!r}; use 'best_of', 'consensus', 'dagma', "
+                "or 'dagma_weighted'."
+            )
+
+        # Run the search to generate multiple DAG hypotheses
+        bootstrap_dags = run_bootstrap(
+            data,
+            indra_priors,
+            prior_strength,
+            scoring_function,
+            search_algorithm,
+            expert_knowledge,
+            add_high_corr_edges_to_priors,
+            corr_threshold,
+            n_bootstrap,
+            convert_to_probability,
+            use_source_counts,
+            run_random_init,
+            subsample_frac=run_frac,
+            replace=run_replace,
+            verbose=verbose,
+        )
+
+        # Reduce the runs to one posterior DAG
+        if selection == "best_of":
+            edge_priors = prepare_indra_priors(
+                indra_priors, convert_to_probability, use_source_counts
+            )
+            best_dag, run_scores = best_scoring_dag(
+                bootstrap_dags, data, edge_priors, scoring_function, prior_strength
+            )
+            posterior_dag = pd.DataFrame(list(best_dag.edges()), columns=["source", "target"])
+        else:
+            cons = consensus_dag(bootstrap_dags, indra_priors, lam=0.25, min_freq=edge_probability)
+            posterior_dag = pd.DataFrame(list(cons.edges()), columns=["source", "target"])
 
     # Convert posterior DAG to y0 graph format
     y0_graph = convert_to_y0_graph(posterior_dag)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -3,15 +3,19 @@
 Covers the causal-path filtering used to prune a posterior graph down to the
 nodes relevant to a treatment/outcome query, and the consensus-DAG aggregation
 that turns a set of bootstrap DAGs plus edge priors into a single acyclic graph.
-The INDRA/bootstrap-driven entry points (extract_indra_prior,
-estimate_posterior_dag, repair_confounding) require external services and are
-not exercised here.
+extract_indra_prior and repair_confounding require external services and are
+not exercised here. estimate_posterior_dag's hill-climb-driven selections
+("best_of"/"consensus") are too heavy for unit tests, but its "dagma" selection
+is a single, cheap continuous-optimization fit and is exercised below (gated
+behind pytest.importorskip("dagma") since it's an optional dependency).
 """
 
 import importlib
 
 import networkx as nx
+import numpy as np
 import pandas as pd
+import pytest
 from y0.dsl import Variable
 from y0.graph import NxMixedGraph
 
@@ -137,3 +141,75 @@ def test_consensus_dag_ignores_none_entries():
     out = net.consensus_dag(dags, priors, min_freq=0.5)
     # Only one valid DAG, edge freq 1.0.
     assert ("X", "Y") in out.edges()
+
+
+def test_estimate_posterior_dag_dagma_selection_restricts_to_prior_edges():
+    pytest.importorskip("dagma")
+
+    rng = np.random.default_rng(0)
+    n = 500
+    A = rng.normal(size=n)
+    B = 2.0 * A + rng.normal(scale=0.1, size=n)
+    C = rng.normal(size=n)  # independent noise, absent from the prior
+    data = pd.DataFrame({"A": A, "B": B, "C": C})
+
+    indra_priors = pd.DataFrame({"source": ["A"], "target": ["B"], "evidence_count": [10]})
+
+    y0_graph, bootstrap_dags = net.estimate_posterior_dag(
+        data,
+        indra_priors,
+        selection="dagma",
+        return_bootstrap_dags=True,
+        verbose=False,
+    )
+
+    edges = {(str(u), str(v)) for u, v in y0_graph.directed.edges()}
+    assert edges == {("A", "B")}
+    # Single deterministic full-data fit -> exactly one candidate DAG.
+    assert len(bootstrap_dags) == 1
+    for u, v in y0_graph.directed.edges():
+        assert y0_graph.directed[u][v]["edge_prob"] == 1.0
+
+
+def test_estimate_posterior_dag_dagma_weighted_selection_uses_evidence_strength():
+    pytest.importorskip("dagma")
+
+    # Two structurally identical edges (A->B, C->D); only the INDRA evidence
+    # strength differs. At this lambda1, plain "dagma" keeps both, but
+    # "dagma_weighted" should favor the well-evidenced edge and drop the
+    # poorly-evidenced one despite the identical true effect size.
+    rng = np.random.default_rng(0)
+    n = 400
+    A = rng.normal(size=n)
+    C = rng.normal(size=n)
+    coef = 0.5
+    B = coef * A + rng.normal(scale=1.0, size=n)
+    D = coef * C + rng.normal(scale=1.0, size=n)
+    data = pd.DataFrame({"A": A, "B": B, "C": C, "D": D})
+
+    indra_priors = pd.DataFrame(
+        {"source": ["A", "C"], "target": ["B", "D"], "evidence_count": [50, 1]}
+    )
+
+    y0_plain = net.estimate_posterior_dag(
+        data.copy(),
+        indra_priors.copy(),
+        selection="dagma",
+        dagma_lambda1=0.3,
+        dagma_w_threshold=0.1,
+        verbose=False,
+    )
+    y0_weighted = net.estimate_posterior_dag(
+        data.copy(),
+        indra_priors.copy(),
+        selection="dagma_weighted",
+        dagma_lambda1=0.3,
+        dagma_w_threshold=0.1,
+        verbose=False,
+    )
+
+    plain_edges = {(str(u), str(v)) for u, v in y0_plain.directed.edges()}
+    weighted_edges = {(str(u), str(v)) for u, v in y0_weighted.directed.edges()}
+
+    assert plain_edges == {("A", "B"), ("C", "D")}
+    assert weighted_edges == {("A", "B")}

--- a/tests/test_prior_data_reconciliation.py
+++ b/tests/test_prior_data_reconciliation.py
@@ -9,6 +9,9 @@ Covers the deterministic / data-transform helpers only:
   with and without the sigmoid probability conversion.
 - remove_high_corr_edges_from_blacklist: blacklist pruning and prior augmentation
   driven by a small correlation setup.
+- _build_dagma_exclude_edges: index-based blacklist construction for DAGMA.
+- run_dagma: the DAGMA baseline, gated behind pytest.importorskip("dagma")
+  since it's an optional dependency.
 
 The pgmpy scoring classes and the Parallel/HillClimb bootstrap drivers
 (process_bootstrap / run_bootstrap) are heavier and are not exercised here.
@@ -19,6 +22,7 @@ import importlib
 import networkx as nx
 import numpy as np
 import pandas as pd
+import pytest
 
 pdr = importlib.import_module("causomic.graph_construction.prior_data_reconciliation")
 
@@ -212,3 +216,237 @@ def test_remove_high_corr_edges_from_blacklist_keeps_low_corr():
     )
     # Correlation below threshold: blacklist edge is preserved.
     assert ("A", "B") in updated_blacklist
+
+
+# ---------------------------------------------------------------------------
+# _build_dagma_exclude_edges
+# ---------------------------------------------------------------------------
+def test_build_dagma_exclude_edges_excludes_everything_not_allowed():
+    nodes = ["A", "B", "C"]
+    allowed = {("A", "B"), ("B", "C")}
+    excluded = pdr._build_dagma_exclude_edges(nodes, allowed)
+
+    index = {n: i for i, n in enumerate(nodes)}
+    allowed_idx = {(index[u], index[v]) for u, v in allowed}
+    all_idx = {(index[u], index[v]) for u in nodes for v in nodes if u != v}
+
+    # DagmaLinear.fit only recognizes exclude_edges when it is literally a
+    # tuple of tuples (a list silently no-ops its internal type check).
+    assert isinstance(excluded, tuple)
+    assert all(isinstance(e, tuple) for e in excluded)
+    assert set(excluded) == all_idx - allowed_idx
+    assert allowed_idx.isdisjoint(set(excluded))
+
+
+def test_build_dagma_exclude_edges_empty_when_all_pairs_allowed():
+    nodes = ["A", "B"]
+    allowed = {("A", "B"), ("B", "A")}
+    assert pdr._build_dagma_exclude_edges(nodes, allowed) == ()
+
+
+# ---------------------------------------------------------------------------
+# run_dagma
+# ---------------------------------------------------------------------------
+def test_run_dagma_only_learns_prior_allowed_edges():
+    pytest.importorskip("dagma")
+
+    rng = np.random.default_rng(0)
+    n = 500
+    A = rng.normal(size=n)
+    B = 2.0 * A + rng.normal(scale=0.1, size=n)
+    C = rng.normal(size=n)  # independent noise, absent from the prior
+    data = pd.DataFrame({"A": A, "B": B, "C": C})
+
+    # Prior only allows A->B; C is left fully unconstrained/unconnected.
+    indra_priors = pd.DataFrame({"source": ["A"], "target": ["B"], "evidence_count": [10]})
+
+    dag = pdr.run_dagma(data, indra_priors, lambda1=0.02, w_threshold=0.2, verbose=False)
+
+    assert set(dag.nodes()) == {"A", "B", "C"}
+    assert nx.is_directed_acyclic_graph(dag)
+    # Only the prior-allowed edge can appear; the strong A->B signal is recovered.
+    assert set(dag.edges()) == {("A", "B")}
+
+
+def test_run_dagma_blocks_true_edge_when_prior_forbids_it():
+    pytest.importorskip("dagma")
+
+    # Same strong linear effect as above, but this time the prior only
+    # allows the reverse direction (B->A), not the true A->B relationship.
+    rng = np.random.default_rng(1)
+    n = 500
+    A = rng.normal(size=n)
+    B = 2.0 * A + rng.normal(scale=0.1, size=n)
+    data = pd.DataFrame({"A": A, "B": B})
+
+    indra_priors = pd.DataFrame({"source": ["B"], "target": ["A"], "evidence_count": [10]})
+
+    dag = pdr.run_dagma(data, indra_priors, lambda1=0.02, w_threshold=0.2, verbose=False)
+
+    # The hard blacklist must prevent A->B even though the data strongly
+    # supports it -- this is the "only allow prior edges" guarantee.
+    assert ("A", "B") not in dag.edges()
+
+
+def test_run_dagma_forwards_fit_kwargs():
+    pytest.importorskip("dagma")
+
+    # A near-degenerate schedule (single outer round, one inner iteration)
+    # should still run and return a valid DAG -- this only checks that
+    # dagma_fit_kwargs actually reaches DagmaLinear.fit, not solution quality.
+    rng = np.random.default_rng(0)
+    n = 100
+    A = rng.normal(size=n)
+    B = 2.0 * A + rng.normal(scale=0.1, size=n)
+    data = pd.DataFrame({"A": A, "B": B})
+    indra_priors = pd.DataFrame({"source": ["A"], "target": ["B"], "evidence_count": [10]})
+
+    dag = pdr.run_dagma(
+        data,
+        indra_priors,
+        lambda1=0.02,
+        w_threshold=0.2,
+        verbose=False,
+        dagma_fit_kwargs={"T": 1, "warm_iter": 1, "max_iter": 1},
+    )
+    assert set(dag.nodes()) == {"A", "B"}
+    assert nx.is_directed_acyclic_graph(dag)
+
+
+# ---------------------------------------------------------------------------
+# evidence_penalty
+# ---------------------------------------------------------------------------
+def test_evidence_penalty_neutral_belief_gives_unit_multiplier():
+    belief = np.array([[0.5, 0.5], [0.5, 0.5]])
+    mask = np.array([[False, True], [False, False]])
+    C = pdr.evidence_penalty(belief, mask)
+    # p=0.5 -> log-odds 0 -> multiplier exp(0) == 1.
+    assert np.isclose(C[0, 1], 1.0)
+
+
+def test_evidence_penalty_strong_evidence_lowers_penalty():
+    belief = np.array([[0.5, 0.95], [0.05, 0.5]])
+    mask = np.array([[False, True], [True, False]])
+    C = pdr.evidence_penalty(belief, mask)
+    # Strong positive evidence (p=0.95) -> multiplier < 1 (encourages the edge).
+    assert C[0, 1] < 1.0
+    # Weak/negative evidence (p=0.05) -> multiplier > 1 (discourages the edge).
+    assert C[1, 0] > 1.0
+
+
+def test_evidence_penalty_only_reweights_masked_positions():
+    belief = np.array([[0.99, 0.01], [0.5, 0.5]])
+    mask = np.array([[False, False], [False, False]])
+    C = pdr.evidence_penalty(belief, mask)
+    # Nothing is masked -> multiplier stays at the DAGMA default of 1.0
+    # everywhere, regardless of how extreme the (unused) belief values are.
+    assert np.array_equal(C, np.ones_like(belief))
+
+
+def test_evidence_penalty_clip_bounds_extreme_log_odds():
+    belief = np.array([[1 - 1e-9]])
+    mask = np.array([[True]])
+    C = pdr.evidence_penalty(belief, mask, clip=1.0)
+    # exp(-clip) is the floor regardless of how extreme belief is.
+    assert np.isclose(C[0, 0], np.exp(-1.0))
+
+
+def test_evidence_penalty_center_removes_uniform_evidence_level():
+    # Both entries have identical (strong) evidence, so their log-odds are
+    # equal; centering subtracts the mean log-odds, leaving zero relative
+    # difference -> multiplier 1.0 for both, unlike the uncentered case.
+    belief = np.array([0.9, 0.9])
+    mask = np.array([True, True])
+
+    uncentered = pdr.evidence_penalty(belief, mask, center=False)
+    assert np.all(uncentered < 1.0)
+
+    centered = pdr.evidence_penalty(belief, mask, center=True)
+    assert np.allclose(centered, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# _build_dagma_belief_matrix
+# ---------------------------------------------------------------------------
+def test_build_dagma_belief_matrix_fills_from_edge_priors():
+    nodes = ["A", "B", "C"]
+    edge_priors = {("A", "B"): 0.9}
+    belief, mask = pdr._build_dagma_belief_matrix(nodes, edge_priors, default_belief=0.5)
+
+    assert belief.shape == (3, 3)
+    assert mask.shape == (3, 3)
+    assert belief[0, 1] == 0.9
+    assert mask[0, 1]
+    # Everywhere else keeps the default belief and is unmasked.
+    unmasked = np.ones((3, 3), dtype=bool)
+    unmasked[0, 1] = False
+    assert np.all(belief[unmasked] == 0.5)
+    assert not mask[unmasked].any()
+
+
+def test_build_dagma_belief_matrix_ignores_unknown_nodes():
+    nodes = ["A", "B"]
+    edge_priors = {("A", "Z"): 0.9, ("A", "B"): 0.7}
+    belief, mask = pdr._build_dagma_belief_matrix(nodes, edge_priors)
+    # ("A", "Z") can't be placed (Z isn't in node_order) and must be skipped
+    # without error; ("A", "B") still lands correctly.
+    assert mask.sum() == 1
+    assert belief[0, 1] == 0.7
+
+
+# ---------------------------------------------------------------------------
+# run_dagma(use_evidence_weights=True)
+# ---------------------------------------------------------------------------
+def _strong_vs_weak_evidence_data(seed=0, n=400, coef=0.5):
+    # Two structurally identical edges (A->B, C->D) with the same true
+    # effect size, so any difference in what survives is attributable to
+    # the evidence weighting rather than the underlying signal strength.
+    rng = np.random.default_rng(seed)
+    A = rng.normal(size=n)
+    C = rng.normal(size=n)
+    B = coef * A + rng.normal(scale=1.0, size=n)
+    D = coef * C + rng.normal(scale=1.0, size=n)
+    data = pd.DataFrame({"A": A, "B": B, "C": C, "D": D})
+    # A->B has strong supporting evidence; C->D has almost none.
+    indra_priors = pd.DataFrame(
+        {"source": ["A", "C"], "target": ["B", "D"], "evidence_count": [50, 1]}
+    )
+    return data, indra_priors
+
+
+def test_run_dagma_evidence_weighting_prunes_weak_evidence_edge_first():
+    pytest.importorskip("dagma")
+    data, indra_priors = _strong_vs_weak_evidence_data()
+
+    unweighted = pdr.run_dagma(
+        data, indra_priors.copy(), lambda1=0.3, w_threshold=0.1, use_evidence_weights=False
+    )
+    weighted = pdr.run_dagma(
+        data, indra_priors.copy(), lambda1=0.3, w_threshold=0.1, use_evidence_weights=True
+    )
+
+    # Unweighted: both same-sized effects survive the uniform L1 penalty.
+    assert set(unweighted.edges()) == {("A", "B"), ("C", "D")}
+    # Weighted: the strong-evidence edge is favored (smaller effective
+    # penalty) and survives; the weak-evidence edge is disfavored and is
+    # pruned despite having the identical true effect size.
+    assert set(weighted.edges()) == {("A", "B")}
+
+
+def test_run_dagma_evidence_weighting_can_rescue_edge_from_over_pruning():
+    pytest.importorskip("dagma")
+    data, indra_priors = _strong_vs_weak_evidence_data()
+
+    # A lambda1 large enough that the uniform L1 penalty prunes every edge,
+    # including the true A->B effect.
+    unweighted = pdr.run_dagma(
+        data, indra_priors.copy(), lambda1=0.5, w_threshold=0.1, use_evidence_weights=False
+    )
+    weighted = pdr.run_dagma(
+        data, indra_priors.copy(), lambda1=0.5, w_threshold=0.1, use_evidence_weights=True
+    )
+
+    assert set(unweighted.edges()) == set()
+    # The strong-evidence edge's lowered effective penalty rescues it from
+    # over-aggressive pruning, while the weak-evidence edge stays excluded.
+    assert set(weighted.edges()) == {("A", "B")}


### PR DESCRIPTION
Adds selection="dagma" and selection="dagma_weighted" alongside the existing best_of/consensus hill-climb selections: a single DAGMA (continuous-optimization) fit hard-restricted to INDRA-prior edges via DagmaLinear's exclude_edges, with an optional per-edge L1 penalty weighted by INDRA evidence log-odds. dagma is an optional, lazily imported dependency (causomic[dagma] extra) so `import causomic` still works without it installed.

Also fixes four correctness issues surfaced during validation:
- run_dagma passed data.values directly into DagmaLinear.fit, which centers by mutating its input array in place; through pandas that silently zero-meant the caller's DataFrame. Now centers into an explicit copy instead.
- run_dagma's docstring claimed the result was "guaranteed acyclic"; DAGMA only approaches acyclicity in the limit of the annealing schedule, so a finite T can leave a residual cycle. Now raises ValueError instead of silently returning one.
- The evidence-weighted L1 penalty (clip=3.0, center=False) could push effective shrinkage past w_threshold regardless of the data, collapsing the soft prior into a second hard mask on weak-belief edges, and made surviving edges' magnitudes incomparable across differing evidence strength. Selected edges are now refit via unpenalized OLS so reported weights are unbiased and comparable.
- evidence_penalty silently produced maximally-discounted weights if fed raw counts instead of probabilities (clipped straight to the clip bound); it now validates belief is in [0, 1] and raises otherwise.