### PR TITLE
Add closed-neighborhood path querying for HPN-DREAM analysis

### DIFF
--- a/src/causomic/graph_construction/prior_data_reconciliation.py
+++ b/src/causomic/graph_construction/prior_data_reconciliation.py
@@ -681,9 +681,9 @@ class BICGaussIndraPriors(LogLikelihoodGauss):
         self.scale_with_n = scale_with_n
         self.interventional = interventional
         if arm_labels is not None:
-            assert arm_labels.index.equals(data.index), (
-                "arm_labels must share data's index (one label per row of data)."
-            )
+            assert arm_labels.index.equals(
+                data.index
+            ), "arm_labels must share data's index (one label per row of data)."
         self.arm_labels = arm_labels
         self.clamped_nodes = clamped_nodes or {}
 
@@ -790,7 +790,8 @@ class BICGaussIndraPriors(LogLikelihoodGauss):
         full parent set - treated as a degenerate fit, not raised on).
         """
         contributing_arms = [
-            arm for arm in pd.unique(self.arm_labels)
+            arm
+            for arm in pd.unique(self.arm_labels)
             if variable not in self.clamped_nodes.get(arm, [])
         ]
         if not contributing_arms:
@@ -1087,7 +1088,10 @@ def process_bootstrap(
             interventional=True, arm_labels=resampled_arm_labels, clamped_nodes=clamped_nodes
         )
     custom_score = score_fn(
-        resampled_data, edge_priors=edge_priors, prior_strength=prior_strength, **interventional_kwargs
+        resampled_data,
+        edge_priors=edge_priors,
+        prior_strength=prior_strength,
+        **interventional_kwargs,
     )
 
     allowed = set(edge_priors.keys())

--- a/src/causomic/graph_construction/prior_data_reconciliation.py
+++ b/src/causomic/graph_construction/prior_data_reconciliation.py
@@ -616,6 +616,18 @@ class BICGaussIndraPriors(LogLikelihoodGauss):
 
     Choose BIC when interpretability and network sparsity are priorities.
     Choose AIC when predictive performance is the primary concern.
+
+    Interventional (GIES-style) scoring
+    ------------------------------------
+    Passing `interventional=True` together with `arm_labels` (and, usually,
+    `clamped_nodes`) switches `local_score` to a second code path that sums
+    log-likelihood contributions across experimental arms instead of fitting one
+    flat GLM over all of `data` - see `local_score` / `_local_score_interventional`.
+    This is strictly opt-in: with the default `interventional=False`, or with
+    `interventional=True` but no `arm_labels`, `local_score` runs the exact same
+    single-GLM-over-self.data code path as before this feature existed. Existing
+    callers (all of which construct this class without either argument) are
+    unaffected byte-for-byte.
     """
 
     def __init__(
@@ -624,12 +636,56 @@ class BICGaussIndraPriors(LogLikelihoodGauss):
         edge_priors: Optional[dict] = None,
         prior_strength: float = 1.0,
         scale_with_n: bool = False,
+        interventional: bool = False,
+        arm_labels: Optional[pd.Series] = None,
+        clamped_nodes: Optional[dict] = None,
         **kwargs,
     ):
+        """
+        Parameters
+        ----------
+        data : pd.DataFrame
+            Observational (or, with `interventional=True`, pooled multi-arm)
+            dataset for scoring.
+        edge_priors : Optional[dict], default=None
+            Dictionary mapping (parent, child) tuples to prior probabilities [0,1].
+        prior_strength : float, default=1.0
+            Scaling factor for prior influence (λ parameter).
+        scale_with_n : bool, default=False
+            See `local_score`'s docstring for the (currently inert - the
+            multiplication is commented out) intended effect.
+        interventional : bool, default=False
+            If True *and* `arm_labels` is given, `local_score` sums per-arm
+            log-likelihoods (skipping arms where `variable` was clamped) instead
+            of fitting one GLM over all of `data`. Default False, and the
+            fallback when `arm_labels` is missing, reproduces prior behavior
+            exactly - see class docstring.
+        arm_labels : Optional[pd.Series], default=None
+            Per-sample experimental-arm label, one entry per row of `data`.
+            Must share `data`'s index. Required for the interventional branch to
+            activate at all; if None, `local_score` always uses the flat
+            observational path regardless of `interventional`.
+        clamped_nodes : Optional[dict], default=None
+            Maps an arm label (as found in `arm_labels`) to the list of node
+            names pharmacologically clamped in that arm. An arm absent from this
+            dict (or the dict being None/empty) is treated as having no clamped
+            nodes. A clamped node is only excluded from *its own* local-score
+            arm-contribution in the arm(s) where it's clamped; it remains a valid
+            regressor for every other variable's score in that same arm - that's
+            the whole point of interventional data (see
+            `_local_score_interventional`).
+        """
         super().__init__(data, **kwargs)
         self.edge_priors = edge_priors or {}
         self.prior_strength = prior_strength  # This is lambda
         self.scale_with_n = scale_with_n
+        self.interventional = interventional
+        if arm_labels is not None:
+            assert arm_labels.index.equals(data.index), (
+                "arm_labels must share data's index (one label per row of data)."
+            )
+        self.arm_labels = arm_labels
+        self.clamped_nodes = clamped_nodes or {}
 
     def local_score(self, variable: str, parents: list) -> float:
         """
@@ -672,7 +728,15 @@ class BICGaussIndraPriors(LogLikelihoodGauss):
 
         Error handling returns -inf for degenerate cases (singular covariance
         matrices, etc.) to exclude them from consideration.
+
+        If `self.interventional` and `self.arm_labels` are both set, this
+        delegates to `_local_score_interventional` instead - see that method.
+        Otherwise (the default), everything below is unchanged from before that
+        branch existed.
         """
+        if self.interventional and self.arm_labels is not None:
+            return self._local_score_interventional(variable, parents)
+
         try:
             ll, df_model = self._log_likelihood(variable=variable, parents=parents)
         except:
@@ -693,6 +757,105 @@ class BICGaussIndraPriors(LogLikelihoodGauss):
         # prior_bonus *= self.prior_strength
         # if self.scale_with_n:
         #     prior_bonus *= np.log(self.data.shape[0])
+        return bic_score + prior_bonus
+
+    def _local_score_interventional(self, variable: str, parents: list) -> float:
+        """
+        GIES-style interventional local score: sum log-likelihood of
+        `variable | parents` across experimental arms, then apply the BIC
+        complexity penalty once over the pooled effective sample size.
+
+        For each arm in `self.arm_labels`, `variable`'s contribution is dropped
+        entirely if `variable` is listed in `self.clamped_nodes[arm]` - a clamped
+        node's value there is experimenter-set, not generated by its parents, so
+        that arm carries no information about *this* edge. Every other arm still
+        contributes, including arms where one of `parents` (not `variable`) is
+        clamped: clamping never removes a column from `self.data`, only changes
+        which arms' *rows* count toward `variable`'s own score, so a clamped
+        parent's (fixed) value remains a perfectly ordinary regressor for scoring
+        `variable` in that arm. This is asserted explicitly below rather than
+        left implicit.
+
+        `_log_likelihood` (inherited from pgmpy's LogLikelihoodGauss) always reads
+        `self.data`, with no data-argument override, so each arm's contribution is
+        computed by temporarily pointing `self.data` at that arm's row-subset,
+        calling `_log_likelihood`, and restoring `self.data` in a `finally` block -
+        reusing the exact same GLM-fitting code the observational branch uses,
+        rather than duplicating it.
+
+        Returns -inf if `variable` is clamped in every arm (nothing to score), if
+        any contributing arm's fit is singular (matches the observational
+        branch's all-or-nothing -inf handling), or if arms disagree on
+        `df_model` (a small, post-resampling arm can be rank-deficient for the
+        full parent set - treated as a degenerate fit, not raised on).
+        """
+        contributing_arms = [
+            arm for arm in pd.unique(self.arm_labels)
+            if variable not in self.clamped_nodes.get(arm, [])
+        ]
+        if not contributing_arms:
+            return -np.inf
+
+        original_data = self.data
+        arm_lls = []
+        arm_df_models = []
+        arm_n_rows = []
+        try:
+            for arm in contributing_arms:
+                arm_data = original_data.loc[self.arm_labels == arm]
+
+                # Clamping a *parent* must never remove it as a regressor for
+                # `variable`'s score in an arm that still contributes - assert
+                # that explicitly rather than assuming the column survived.
+                missing_parent_cols = [p for p in parents if p not in arm_data.columns]
+                assert not missing_parent_cols, (
+                    f"Parent column(s) {missing_parent_cols} missing from arm "
+                    f"{arm!r}'s data - a clamped parent must remain usable as a "
+                    "regressor in every arm where it isn't the variable being scored."
+                )
+                if arm_data.empty:
+                    continue
+
+                self.data = arm_data
+                try:
+                    ll, df_model = self._log_likelihood(variable=variable, parents=parents)
+                except Exception:
+                    return -np.inf
+                finally:
+                    self.data = original_data
+
+                arm_lls.append(ll)
+                arm_df_models.append(df_model)
+                arm_n_rows.append(len(arm_data))
+        finally:
+            self.data = original_data
+
+        if len(set(arm_df_models)) != 1:
+            # A contributing arm can legitimately have too few (post-resampling)
+            # rows to estimate the full parameter set - e.g. a bootstrap
+            # resample of a 6-row arm can leave 1-2 rows, so statsmodels' GLM
+            # fit there is rank-deficient and reports a SMALLER df_model than an
+            # arm with enough rows for every parent. That's not a bug to raise
+            # on (unlike the missing-parent-column case above, which can never
+            # legitimately happen) - it's a degenerate fit, treated the same as
+            # any other singular fit: exclude this candidate.
+            return -np.inf
+        df_model = arm_df_models[0]
+        n_eff = sum(arm_n_rows)
+
+        # Complexity penalty applied ONCE over n_eff (pooled rows across
+        # contributing arms) - not per-arm, per the class's interventional-scoring
+        # contract.
+        bic_score = sum(arm_lls) - (((df_model + 2) / 2) * np.log(n_eff))
+
+        # Soft prior component - identical to the observational branch.
+        prior_bonus = 0
+        for parent in parents:
+            p = self.edge_priors[(parent, variable)]
+            p = np.clip(p, 1e-6, 1 - 1e-6)  # Avoid log(0)
+            log_odds = np.log(p / (1 - p))
+            prior_bonus += log_odds
+
         return bic_score + prior_bonus
 
 
@@ -759,6 +922,39 @@ def random_acyclic_subgraph(nodes, allowed_edges, inclusion_prob=0.15, rng=None,
     return dag
 
 
+def _resample_with_arm_floor(
+    combined: pd.DataFrame,
+    arm_col: str,
+    frac: float,
+    replace: bool,
+    floor: int,
+    rng: np.random.RandomState,
+) -> pd.DataFrame:
+    """Bootstrap-resample ``combined``, holding any arm smaller than ``floor`` rows fixed.
+
+    An arm with fewer rows than ``floor`` carries too little information to usefully
+    bootstrap: with-replacement resampling at a typical ``frac<1`` setting collapses it
+    to just 1-2 unique rows a meaningful fraction of the time, which isn't enough to
+    identify a multi-parent GLM fit and mostly produces candidates that get discarded as
+    singular (see the HPN-DREAM interventional consensus run that motivated this - a
+    6-row arm resampled at frac=0.65 from a 30-row pool got <=2 rows ~20% of the time).
+    Those arms are kept in full, unresampled, on every draw; only arms at or above
+    ``floor`` rows are bootstrap-resampled at (``frac``, ``replace``). ``floor=0``
+    (the default everywhere this is called) reproduces the original single pooled
+    ``.sample(...)`` call exactly, so this is opt-in only.
+    """
+    if not floor:
+        return combined.sample(frac=frac, replace=replace, random_state=rng)
+
+    parts = []
+    for _, arm_group in combined.groupby(arm_col, sort=False):
+        if len(arm_group) < floor:
+            parts.append(arm_group)
+        else:
+            parts.append(arm_group.sample(frac=frac, replace=replace, random_state=rng))
+    return pd.concat(parts)
+
+
 def process_bootstrap(
     data: pd.DataFrame,
     edge_priors: dict,
@@ -770,6 +966,10 @@ def process_bootstrap(
     random_init: bool = False,
     subsample_frac: float = 0.65,
     replace: bool = True,
+    interventional: bool = False,
+    arm_labels: Optional[pd.Series] = None,
+    clamped_nodes: Optional[dict] = None,
+    arm_resample_floor: int = 0,
 ) -> Optional[DAG]:
     """
     Process single bootstrap sample for causal discovery with uncertainty quantification.
@@ -803,6 +1003,22 @@ def process_bootstrap(
         If True, initialize the hill climb search from a random acyclic subgraph
         rather than an empty DAG. This can help escape local optima but increases
         run-to-run variability. Default is False.
+    interventional : bool, optional
+        Passed through to `score_fn` (only meaningful for a scoring class that
+        supports it, e.g. `BICGaussIndraPriors`). Default is False, which never
+        changes this function's resampling or scoring-construction code path -
+        see Notes.
+    arm_labels : Optional[pd.Series], optional
+        Per-sample experimental-arm label aligned to `data`'s index. Required
+        for `interventional` to take effect - default is None.
+    clamped_nodes : Optional[dict], optional
+        Passed through to `score_fn` unchanged when `interventional` is True.
+    arm_resample_floor : int, optional
+        Only meaningful when `arm_labels` is not None. Arms with fewer than this many
+        rows are kept in full (unresampled) on every bootstrap draw rather than being
+        bootstrap-resampled at (`subsample_frac`, `replace`) like the rest of the data
+        - see `_resample_with_arm_floor`. Default is 0, which disables this and
+        reproduces the original single pooled `.sample(...)` call exactly.
 
     Returns
     -------
@@ -829,6 +1045,11 @@ def process_bootstrap(
 
     The logging suppression prevents verbose output during parallel execution
     while maintaining error reporting for debugging.
+
+    With `arm_labels=None` (the default), `resampled_data`/`custom_score`
+    construction are exactly what they were before `interventional` existed -
+    the two branches below are never merged into one code path so that case
+    stays byte-for-byte unchanged.
     """
     import logging
 
@@ -839,10 +1060,35 @@ def process_bootstrap(
     rng = np.random.RandomState(seed)
     # subsample_frac<1 with replace=True -> a bootstrap resample (consensus mode);
     # subsample_frac=1 with replace=False -> the full data (best-of-restarts mode).
-    resampled_data = data.sample(frac=subsample_frac, replace=replace, random_state=rng)
+    if arm_labels is not None:
+        # Resample data and arm_labels TOGETHER, in one .sample() call on a
+        # combined frame, so a bootstrap resample can never desynchronize which
+        # arm label goes with which resampled row. Two separate .sample() calls
+        # sharing one RandomState would each advance its internal state and draw
+        # DIFFERENT rows on the second call - not the "same" resample.
+        combined = data.copy()
+        combined["__arm_label__"] = arm_labels
+        resampled_combined = _resample_with_arm_floor(
+            combined, "__arm_label__", subsample_frac, replace, arm_resample_floor, rng
+        )
+        resampled_arm_labels = resampled_combined.pop("__arm_label__")
+        resampled_data = resampled_combined
+    else:
+        resampled_data = data.sample(frac=subsample_frac, replace=replace, random_state=rng)
+        resampled_arm_labels = None
 
-    # Initialize the custom scoring function
-    custom_score = score_fn(resampled_data, edge_priors=edge_priors, prior_strength=prior_strength)
+    # Initialize the custom scoring function. interventional_kwargs stays empty
+    # unless interventional=True was explicitly requested, so score_fn classes
+    # that don't accept these kwargs at all (anything but BICGaussIndraPriors,
+    # today) are unaffected by this parameter existing.
+    interventional_kwargs = {}
+    if interventional:
+        interventional_kwargs = dict(
+            interventional=True, arm_labels=resampled_arm_labels, clamped_nodes=clamped_nodes
+        )
+    custom_score = score_fn(
+        resampled_data, edge_priors=edge_priors, prior_strength=prior_strength, **interventional_kwargs
+    )
 
     allowed = set(edge_priors.keys())
     est = estimator(data=resampled_data, allowed_additions=allowed)
@@ -1144,6 +1390,10 @@ def run_bootstrap(
     subsample_frac: float = 0.65,
     replace: bool = True,
     verbose: bool = True,
+    interventional: bool = False,
+    arm_labels: Optional[pd.Series] = None,
+    clamped_nodes: Optional[dict] = None,
+    arm_resample_floor: int = 0,
 ) -> list:
     """
     Run parallel bootstrap analysis for robust causal discovery with INDRA priors.
@@ -1246,6 +1496,12 @@ def run_bootstrap(
 
     The choice depends on computational resources and required precision
     for downstream biological interpretation and hypothesis generation.
+
+    interventional, arm_labels, clamped_nodes, arm_resample_floor are forwarded to
+    `process_bootstrap` (and from there to `score_fn`) unchanged - default is
+    `interventional=False`, `arm_labels=None`, `arm_resample_floor=0`, which never
+    alters this function's own behavior; only the values ultimately reaching
+    `process_bootstrap` change.
     """
     if verbose:
         print("INFO: Starting bootstrap causal discovery:")
@@ -1280,6 +1536,10 @@ def run_bootstrap(
             random_init=random_init,
             subsample_frac=subsample_frac,
             replace=replace,
+            interventional=interventional,
+            arm_labels=arm_labels,
+            clamped_nodes=clamped_nodes,
+            arm_resample_floor=arm_resample_floor,
         )
         for i in tqdm(range(n_bootstrap), desc="Hill Climb runs")
     )

--- a/src/causomic/graph_construction/utils_nx.py
+++ b/src/causomic/graph_construction/utils_nx.py
@@ -537,6 +537,7 @@ def query_forward_paths(
     n_mediators: int = 1,
     med_ev_filter: Optional[List[int]] = None,
     med_src_filter: Optional[List[int]] = None,
+    exclude_other_starts: bool = True,
     verbose: bool = True,
 ) -> pd.DataFrame:
     """Search for simple forward paths from any start node to any end node.
@@ -552,10 +553,19 @@ def query_forward_paths(
     end nodes. This corresponds to path lengths of ``mediator_count + 1``
     edges, subject to the corresponding evidence and source count thresholds.
 
-    Paths are not allowed to pass through any other start node: when
-    searching from a given ``start`` to a given ``end``, any node in
-    ``start_nodes`` other than ``start`` (and ``end`` itself, if it happens
-    to be in ``start_nodes``) is excluded from intermediate traversal.
+    When ``exclude_other_starts`` is True (the default), paths are not
+    allowed to pass through any other start node: when searching from a
+    given ``start`` to a given ``end``, any node in ``start_nodes`` other
+    than ``start`` (and ``end`` itself, if it happens to be in
+    ``start_nodes``) is excluded from intermediate traversal. This is the
+    right behavior when ``start_nodes`` and ``end_nodes`` are genuinely
+    distinct groups (e.g. drug targets vs. disease targets) and a path
+    shouldn't be credited to routing through another root cause.
+
+    Set ``exclude_other_starts=False`` for the closed-neighborhood case
+    where ``start_nodes`` and ``end_nodes`` are the same list of nodes and
+    you want all pairwise relations among them, including ones mediated by
+    other members of that same list (see :func:`query_neighborhood_paths`).
 
     Args:
         graph: DiGraph annotated with evidence counts on edges.
@@ -569,6 +579,10 @@ def query_forward_paths(
         med_src_filter: Per-depth source-count thresholds: a list of length
             ``n_mediators + 1`` where index ``i`` applies to paths with
             ``i`` mediators. If None, defaults to all ones.
+        exclude_other_starts: If True (default), other nodes in
+            ``start_nodes`` are excluded from intermediate traversal for any
+            given (start, end) pair. Set to False to allow other start nodes
+            to serve as mediators.
 
     Returns:
         A pandas.DataFrame with rows for each edge that appears on any
@@ -604,7 +618,7 @@ def query_forward_paths(
             continue
 
         for end in end_nodes_list:
-            excluded = start_nodes_set - {start, end}
+            excluded = (start_nodes_set - {start, end}) if exclude_other_starts else set()
 
             for med in range(0, n_mediators + 1):
                 cutoff = med + 1
@@ -636,3 +650,56 @@ def query_forward_paths(
     )
 
     return forward_df
+
+
+def query_neighborhood_paths(
+    graph: nx.DiGraph,
+    nodes: Iterable[str],
+    n_mediators: int = 1,
+    med_ev_filter: Optional[List[int]] = None,
+    med_src_filter: Optional[List[int]] = None,
+    verbose: bool = True,
+) -> pd.DataFrame:
+    """Find all pairwise INDRA relations among a single list of nodes.
+
+    Thin wrapper around :func:`query_forward_paths` for the closed-set case:
+    every node in ``nodes`` is used as both a start and an end node, and
+    ``exclude_other_starts`` is forced to False so that other members of
+    ``nodes`` are allowed to serve as mediators between any given pair
+    instead of being excluded as "other start nodes" (see
+    :func:`query_forward_paths` for why that exclusion exists and why it
+    would otherwise block legitimate internal mediators here).
+
+    Mediator eligibility beyond this is governed entirely by ``graph``, not
+    by this function: if mediators should be limited to a known set of
+    measured proteins, build ``graph`` via
+    ``prepare_graph(raw_graph, measured_nodes=nodes)`` (or another
+    appropriate node set) before calling this function.
+
+    Args:
+        graph: DiGraph annotated with evidence counts on edges.
+        nodes: Iterable of node ids defining the closed neighborhood.
+        n_mediators: Maximum number of intermediate nodes allowed on a
+            path between any two nodes (path length = n_mediators + 1 edges).
+        med_ev_filter: Per-depth evidence-count thresholds, forwarded to
+            :func:`query_forward_paths`.
+        med_src_filter: Per-depth source-count thresholds, forwarded to
+            :func:`query_forward_paths`.
+        verbose: Forwarded to :func:`query_forward_paths`.
+
+    Returns:
+        A pandas.DataFrame with rows for each edge that appears on any
+        discovered path. Columns: ["source", "target", "evidence_count",
+        "source_count"].
+    """
+    nodes_list = list(nodes)
+    return query_forward_paths(
+        graph,
+        start_nodes=nodes_list,
+        end_nodes=nodes_list,
+        n_mediators=n_mediators,
+        med_ev_filter=med_ev_filter,
+        med_src_filter=med_src_filter,
+        exclude_other_starts=False,
+        verbose=verbose,
+    )

--- a/src/causomic/network.py
+++ b/src/causomic/network.py
@@ -29,7 +29,7 @@ Dependencies:
 import copy
 import os
 from collections import Counter
-from typing import Iterable, Set
+from typing import Iterable, Optional, Set
 
 import networkx as nx
 import numpy as np
@@ -292,7 +292,16 @@ def consensus_dag(bootstrap_dags, indra_priors, lam=0.25, min_freq=0.5):
     return G
 
 
-def best_scoring_dag(dags, data, edge_priors, scoring_function, prior_strength):
+def best_scoring_dag(
+    dags,
+    data,
+    edge_priors,
+    scoring_function,
+    prior_strength,
+    interventional: bool = False,
+    arm_labels=None,
+    clamped_nodes=None,
+):
     """Select the single highest-scoring acyclic DAG from candidate runs.
 
     Each candidate is scored by its total local score
@@ -314,6 +323,16 @@ def best_scoring_dag(dags, data, edge_priors, scoring_function, prior_strength):
         more heavily than AIC and is the recommended choice here.
     prior_strength : float
         Passed through to the scoring function.
+    interventional : bool, optional
+        Forwarded to ``scoring_function`` only when True (default False never
+        adds these kwargs to the ``scoring_function(...)`` call at all, so
+        scoring classes without this parameter are unaffected).
+    arm_labels : Optional[pd.Series], optional
+        Per-sample experimental-arm label aligned to ``data``'s index. Unlike
+        ``run_bootstrap``'s bootstrap resamples, ``data`` here is used as-is
+        (never resampled), so ``arm_labels`` is passed through unmodified.
+    clamped_nodes : Optional[dict], optional
+        Forwarded to ``scoring_function`` unchanged when ``interventional`` is True.
 
     Returns
     -------
@@ -322,7 +341,14 @@ def best_scoring_dag(dags, data, edge_priors, scoring_function, prior_strength):
         columns if none are valid); ``scores`` is the per-candidate total score
         (``None`` for missing or cyclic runs), aligned with ``dags``.
     """
-    scorer = scoring_function(data, edge_priors=edge_priors, prior_strength=prior_strength)
+    interventional_kwargs = {}
+    if interventional:
+        interventional_kwargs = dict(
+            interventional=True, arm_labels=arm_labels, clamped_nodes=clamped_nodes
+        )
+    scorer = scoring_function(
+        data, edge_priors=edge_priors, prior_strength=prior_strength, **interventional_kwargs
+    )
     best, best_score, scores = None, -np.inf, []
     for dag in dags:
         if dag is None:
@@ -361,6 +387,11 @@ def estimate_posterior_dag(
     selection: str = "best_of",
     return_runs: bool = False,
     verbose: bool = True,
+    interventional: bool = False,
+    arm_labels: Optional[pd.Series] = None,
+    clamped_nodes: Optional[dict] = None,
+    arm_resample_floor: int = 0,
+    consensus_subsample_frac: Optional[float] = None,
 ) -> NxMixedGraph:
     """
     Estimate a posterior directed acyclic graph (DAG) using bootstrap sampling.
@@ -423,6 +454,48 @@ def estimate_posterior_dag(
         If True, initialize each bootstrap hill climb from a random acyclic subgraph
         rather than an empty DAG. This can help escape local optima at the cost of
         increased run-to-run variability. Default is False.
+
+    interventional : bool, optional
+        If True (and `arm_labels` is given), every scorer constructed inside this
+        call - both the per-restart/per-resample scorers in `run_bootstrap` and,
+        for `selection="best_of"`, the final re-scoring in `best_scoring_dag` -
+        uses `scoring_function`'s GIES-style interventional local score instead
+        of a single flat GLM fit over all of `data`. Default False, and the
+        fallback whenever `arm_labels` is None, reproduces this function's prior
+        behavior exactly - `scoring_function` is never even passed these kwargs
+        in that case. Only meaningful with a `scoring_function` that supports
+        `interventional`/`arm_labels`/`clamped_nodes` (currently
+        `BICGaussIndraPriors`).
+
+    arm_labels : Optional[pd.Series], optional
+        Per-sample experimental-arm label, one entry per row of `data`, sharing
+        `data`'s index. Required for `interventional` to take effect.
+
+    clamped_nodes : Optional[dict], optional
+        Maps an arm label (as found in `arm_labels`) to the list of node names
+        pharmacologically clamped in that arm. Forwarded unchanged wherever
+        `interventional` is active - see `BICGaussIndraPriors`.
+
+    arm_resample_floor : int, optional
+        Only meaningful when `arm_labels` is not None and `selection="consensus"`
+        (i.e. `subsample_frac<1`) - `selection="best_of"` never resamples at all, so
+        this has no effect there. Arms with fewer than this many rows are kept in full
+        on every bootstrap draw rather than being bootstrap-resampled like the rest of
+        the data, since a small arm resampled at a typical frac<1 collapses to too few
+        unique rows to reliably fit a multi-parent model - see
+        `prior_data_reconciliation._resample_with_arm_floor`. Default is 0, which
+        disables this and reproduces the original pooled-resample behavior exactly.
+
+    consensus_subsample_frac : Optional[float], optional
+        Only meaningful for `selection="consensus"` - overrides its hardcoded
+        `subsample_frac=0.65`. Added for contexts where the full dataset is already so
+        small (e.g. n=5-6) that a further 65% subsample collapses to too few rows to
+        fit almost any candidate parent set (near-universal degenerate/-inf scores,
+        see BT20's HPN-DREAM contexts). `consensus_subsample_frac=1.0` recovers the
+        standard bootstrap (resample with replacement at the original size, not a
+        smaller subsample) while still producing genuine resampling variability for the
+        edge vote. Default `None` leaves the original 0.65 behavior exactly unchanged -
+        this parameter has zero effect unless explicitly set.
 
     Returns
     -------
@@ -514,6 +587,8 @@ def estimate_posterior_dag(
         run_frac, run_replace, run_random_init = 1.0, False, True
     elif selection == "consensus":
         run_frac, run_replace, run_random_init = 0.65, True, random_init
+        if consensus_subsample_frac is not None:
+            run_frac = consensus_subsample_frac
     else:
         raise ValueError(f"Unknown selection={selection!r}; use 'best_of' or 'consensus'.")
 
@@ -534,6 +609,10 @@ def estimate_posterior_dag(
         subsample_frac=run_frac,
         replace=run_replace,
         verbose=verbose,
+        interventional=interventional,
+        arm_labels=arm_labels,
+        clamped_nodes=clamped_nodes,
+        arm_resample_floor=arm_resample_floor,
     )
 
     # Reduce the runs to one posterior DAG
@@ -541,7 +620,14 @@ def estimate_posterior_dag(
     if selection == "best_of":
         edge_priors = prepare_indra_priors(indra_priors, convert_to_probability, use_source_counts)
         best_dag, run_scores = best_scoring_dag(
-            bootstrap_dags, data, edge_priors, scoring_function, prior_strength
+            bootstrap_dags,
+            data,
+            edge_priors,
+            scoring_function,
+            prior_strength,
+            interventional=interventional,
+            arm_labels=arm_labels,
+            clamped_nodes=clamped_nodes,
         )
         posterior_dag = pd.DataFrame(list(best_dag.edges()), columns=["source", "target"])
     else:

--- a/src/causomic/simulation/proteomics_simulator.py
+++ b/src/causomic/simulation/proteomics_simulator.py
@@ -232,15 +232,14 @@ def simulate_data(
         else:
             temp_int = None
 
-        parents = [
-            p for p in node_coefficients if p not in ("intercept", "error", "cell_type")
-        ]
+        parents = [p for p in node_coefficients if p not in ("intercept", "error", "cell_type")]
         parent_centers = {
             p: (baseline_means[p] if p in shifted_nodes else data[p].mean()) for p in parents
         }
 
-        data[node] = simulate_node(data, node_coefficients, n, cell_type, temp_int, node,
-                                    parent_centers=parent_centers)
+        data[node] = simulate_node(
+            data, node_coefficients, n, cell_type, temp_int, node, parent_centers=parent_centers
+        )
 
     if cell_type:
         data["cell_type"] = np.repeat([i for i in range(n_cells)], n // n_cells)

--- a/src/causomic/simulation/proteomics_simulator.py
+++ b/src/causomic/simulation/proteomics_simulator.py
@@ -204,6 +204,25 @@ def simulate_data(
 
     sorted_nodes = [i for i in nx.topological_sort(graph) if i != "cell_type"]
 
+    # Every node's expected value under pure observation equals its intercept
+    # (mean-centering makes each parent's contribution vanish in expectation,
+    # recursively) - same invariant random_network.ground_truth_interventional_effect
+    # relies on. Needed below so a child of a SHIFTED parent centers on that
+    # parent's true baseline rather than the parent's own batch mean - see
+    # simulate_node's docstring for why that distinction matters.
+    baseline_means = {node: coefficients[node]["intercept"] for node in sorted_nodes}
+
+    # A node's batch mean no longer estimates its own baseline once its
+    # distribution has been shifted by an intervention - either directly (it's
+    # in `intervention`) or by inheriting the shift from an upstream ancestor
+    # (it's a descendant of some intervened node). Every such "shifted" node's
+    # CHILDREN must center on its baseline, not its batch mean, or the shift
+    # cancels itself out one hop further downstream than where it was applied.
+    shifted_nodes = set(intervention.keys())
+    for iv_node in intervention:
+        if iv_node in graph:
+            shifted_nodes |= nx.descendants(graph, iv_node)
+
     if verbose:
         print("simulating data...")
     for node in sorted_nodes:
@@ -213,7 +232,15 @@ def simulate_data(
         else:
             temp_int = None
 
-        data[node] = simulate_node(data, node_coefficients, n, cell_type, temp_int, node)
+        parents = [
+            p for p in node_coefficients if p not in ("intercept", "error", "cell_type")
+        ]
+        parent_centers = {
+            p: (baseline_means[p] if p in shifted_nodes else data[p].mean()) for p in parents
+        }
+
+        data[node] = simulate_node(data, node_coefficients, n, cell_type, temp_int, node,
+                                    parent_centers=parent_centers)
 
     if cell_type:
         data["cell_type"] = np.repeat([i for i in range(n_cells)], n // n_cells)
@@ -384,6 +411,7 @@ def simulate_node(
     cell_type: bool,
     intervention: Optional[float],
     node_name: str,
+    parent_centers: Optional[Dict[str, float]] = None,
 ) -> np.ndarray:
     """
     Simulate data for a single node using its structural equation.
@@ -409,6 +437,26 @@ def simulate_node(
         If provided, overrides structural equation simulation.
     node_name : str
         Name of the node being simulated (used for special output handling)
+    parent_centers : Optional[Dict[str, float]], default=None
+        Value to mean-center each parent on, keyed by parent name. If a parent
+        is omitted (or this is None), falls back to that parent's own batch
+        mean (``data[parent].mean()``) - the original, pre-existing behavior.
+
+        This must be set to the parent's TRUE observational baseline (its own
+        ``intercept`` - see ``simulate_data``'s ``baseline_means``) for any
+        parent whose distribution has been shifted by an intervention -
+        either directly (the parent itself was intervened upon) or by
+        inheriting the shift from an upstream ancestor that was. Such a
+        parent's own batch mean no longer estimates its true baseline (an
+        intervened parent's column is a constant equal to the intervention
+        value, so its batch mean IS that constant), so centering on it would
+        make ``data[parent] - data[parent].mean()`` identically zero for
+        every row, discarding the shift's effect on this node entirely -
+        whether that shift originated here or several hops upstream. For a
+        parent whose distribution was never touched by any intervention, its
+        own batch mean remains the right choice (self-corrects for
+        finite-sample deviation from that parent's true intercept, which is
+        the point of mean-centering at all).
 
     Returns
     -------
@@ -471,8 +519,16 @@ def simulate_node(
 
     for parent in parents:
         # Mean-center parent values so the intercept always represents the
-        # expected value of this node regardless of cascade depth.
-        node_data += coefficients[parent] * (data[parent] - data[parent].mean())
+        # expected value of this node regardless of cascade depth. Center on
+        # parent_centers[parent] when given (needed for an intervened parent -
+        # see this function's docstring); otherwise fall back to the parent's
+        # own batch mean, exactly as before this parameter existed.
+        center = (
+            parent_centers[parent]
+            if parent_centers is not None and parent in parent_centers
+            else data[parent].mean()
+        )
+        node_data += coefficients[parent] * (data[parent] - center)
 
     if cell_type & ("cell_type" in coefficients.keys()):
         ## add in cell_effect

--- a/tests/test_network_interventional.py
+++ b/tests/test_network_interventional.py
@@ -33,6 +33,7 @@ the information to prefer A->B in a full-graph comparison. These tests
 therefore only assert the robust part (B->C recovered, C->B never appears) -
 see the local_score-level test for the full orientation-identification claim.
 """
+
 import importlib
 
 import numpy as np
@@ -177,18 +178,30 @@ def test_estimate_posterior_dag_consensus_subsample_frac_override():
 
     with patch.object(net, "run_bootstrap", wraps=net.run_bootstrap) as spy:
         net.estimate_posterior_dag(
-            data.copy(), indra_priors, prior_strength=5.0,
-            scoring_function=pdr.BICGaussIndraPriors, search_algorithm=pdr.SparseHillClimb,
-            n_bootstrap=5, edge_probability=0.5, selection="consensus", verbose=False,
+            data.copy(),
+            indra_priors,
+            prior_strength=5.0,
+            scoring_function=pdr.BICGaussIndraPriors,
+            search_algorithm=pdr.SparseHillClimb,
+            n_bootstrap=5,
+            edge_probability=0.5,
+            selection="consensus",
+            verbose=False,
             consensus_subsample_frac=1.0,
         )
         assert spy.call_args.kwargs["subsample_frac"] == 1.0
 
     with patch.object(net, "run_bootstrap", wraps=net.run_bootstrap) as spy:
         net.estimate_posterior_dag(
-            data.copy(), indra_priors, prior_strength=5.0,
-            scoring_function=pdr.BICGaussIndraPriors, search_algorithm=pdr.SparseHillClimb,
-            n_bootstrap=5, edge_probability=0.5, selection="consensus", verbose=False,
+            data.copy(),
+            indra_priors,
+            prior_strength=5.0,
+            scoring_function=pdr.BICGaussIndraPriors,
+            search_algorithm=pdr.SparseHillClimb,
+            n_bootstrap=5,
+            edge_probability=0.5,
+            selection="consensus",
+            verbose=False,
         )
         assert spy.call_args.kwargs["subsample_frac"] == 0.65
 

--- a/tests/test_network_interventional.py
+++ b/tests/test_network_interventional.py
@@ -1,0 +1,213 @@
+"""Integration coverage for estimate_posterior_dag's interventional (GIES-style)
+plumbing added alongside BICGaussIndraPriors._local_score_interventional.
+
+estimate_posterior_dag itself isn't exercised by tests/test_network.py (its own
+docstring dismisses the INDRA/bootstrap-driven entry points as "requiring
+external services"), but that's not actually true here: given a plain data
+DataFrame and a prior DataFrame, it needs no network access at all - it's just
+heavier (bootstrap + hill climb), which these tests keep small/fast (n_bootstrap
+in the tens, not the hundreds) rather than skipping.
+
+Uses the same synthetic A->B->C chain (with an interventional arm clamping B)
+as tests/test_prior_data_reconciliation.py's local_score-level chain-orientation
+test, but end-to-end through estimate_posterior_dag -> run_bootstrap ->
+process_bootstrap -> the scorer, for both selection modes ("best_of" and
+"consensus"), to catch plumbing bugs (e.g. arm_labels desynchronizing from a
+bootstrap resample) that a local_score-only test can't see.
+
+One deliberately-scoped-down expectation: the local_score-level test proves
+interventional scoring gives the TRUE full-graph hypothesis (A->B->C) a
+decisively higher TOTAL score than its Markov-equivalent reverse (C->B->A).
+That is a clean two-hypothesis comparison. A greedy hill-climb search doesn't
+evaluate hypotheses that way - it adds/removes one edge at a time, and
+`local_score("A", ["B"])` in isolation (not paired against the "A has no
+parent" alternative under the reverse hypothesis) prefers B as a parent
+regardless of orientation, because B still correlates with A in the
+observational arm even though that correlation reflects B depending on A, not
+the other way round. Empirically (checked across 10 runs, 5 seeds x both
+selection modes), this means the search reliably recovers B->C (never C->B -
+C's dependence on B is real in BOTH arms, so that edge has no ambiguity at the
+per-edge level either) but the A<->B edge's orientation is close to a coin
+flip through this specific search procedure, even though the data contains
+the information to prefer A->B in a full-graph comparison. These tests
+therefore only assert the robust part (B->C recovered, C->B never appears) -
+see the local_score-level test for the full orientation-identification claim.
+"""
+import importlib
+
+import numpy as np
+import pandas as pd
+
+net = importlib.import_module("causomic.network")
+pdr = importlib.import_module("causomic.graph_construction.prior_data_reconciliation")
+
+
+def _chain_data_with_intervention_arm(seed: int = 1, n_obs: int = 80, n_clamp: int = 80):
+    rng = np.random.default_rng(seed)
+
+    a_obs = rng.normal(0, 1, n_obs)
+    b_obs = 1.5 * a_obs + rng.normal(0, 0.5, n_obs)
+    c_obs = 1.5 * b_obs + rng.normal(0, 0.5, n_obs)
+
+    a_clamp = rng.normal(0, 1, n_clamp)
+    b_clamp = rng.uniform(-3, 3, n_clamp)
+    c_clamp = 1.5 * b_clamp + rng.normal(0, 0.5, n_clamp)
+
+    data = pd.DataFrame(
+        {
+            "A": np.concatenate([a_obs, a_clamp]),
+            "B": np.concatenate([b_obs, b_clamp]),
+            "C": np.concatenate([c_obs, c_clamp]),
+        }
+    )
+    arm_labels = pd.Series(["obs"] * n_obs + ["clampB"] * n_clamp, index=data.index)
+    clamped_nodes = {"clampB": ["B"]}
+
+    # Prior allows the true chain's edges plus their reverses - the search has to
+    # pick between them using the scorer, not because the prior already decided.
+    indra_priors = pd.DataFrame(
+        {
+            "source": ["A", "B", "B", "C"],
+            "target": ["B", "A", "C", "B"],
+            "evidence_count": [10, 10, 10, 10],
+        }
+    )
+    return data, arm_labels, clamped_nodes, indra_priors
+
+
+def test_estimate_posterior_dag_interventional_best_of_recovers_b_to_c():
+    data, arm_labels, clamped_nodes, indra_priors = _chain_data_with_intervention_arm()
+    allowed_edges = {("A", "B"), ("B", "A"), ("B", "C"), ("C", "B")}
+
+    y0_graph = net.estimate_posterior_dag(
+        data.copy(),
+        indra_priors,
+        prior_strength=5.0,
+        scoring_function=pdr.BICGaussIndraPriors,
+        search_algorithm=pdr.SparseHillClimb,
+        n_bootstrap=30,
+        edge_probability=0.5,
+        selection="best_of",
+        interventional=True,
+        arm_labels=arm_labels,
+        clamped_nodes=clamped_nodes,
+        verbose=False,
+    )
+    edges = {(str(u), str(v)) for u, v in y0_graph.directed.edges()}
+    assert edges, "expected a non-trivial learned network"
+    assert edges <= allowed_edges, f"unexpected edge(s) outside the prior: {edges - allowed_edges}"
+    # The robust part of the claim - see module docstring for why A<->B's
+    # orientation isn't asserted here.
+    assert ("B", "C") in edges
+    assert ("C", "B") not in edges
+
+
+def test_estimate_posterior_dag_interventional_consensus_recovers_b_to_c():
+    data, arm_labels, clamped_nodes, indra_priors = _chain_data_with_intervention_arm(seed=2)
+    allowed_edges = {("A", "B"), ("B", "A"), ("B", "C"), ("C", "B")}
+
+    y0_graph = net.estimate_posterior_dag(
+        data.copy(),
+        indra_priors,
+        prior_strength=5.0,
+        scoring_function=pdr.BICGaussIndraPriors,
+        search_algorithm=pdr.SparseHillClimb,
+        n_bootstrap=30,
+        edge_probability=0.5,
+        selection="consensus",
+        interventional=True,
+        arm_labels=arm_labels,
+        clamped_nodes=clamped_nodes,
+        verbose=False,
+    )
+    edges = {(str(u), str(v)) for u, v in y0_graph.directed.edges()}
+    assert edges, "expected a non-trivial learned network"
+    assert edges <= allowed_edges, f"unexpected edge(s) outside the prior: {edges - allowed_edges}"
+    assert ("B", "C") in edges
+    assert ("C", "B") not in edges
+
+
+def test_estimate_posterior_dag_consensus_with_arm_resample_floor_recovers_b_to_c():
+    """arm_resample_floor keeps a small clamped arm intact across bootstrap draws
+    instead of letting consensus's frac=0.65 resampling collapse it to a handful
+    of rows - added after that exact failure mode (rank-deficient GLM fits from an
+    over-resampled small arm) showed up running the real HPN-DREAM pilot data.
+    Shrinks the clamped arm down to a size where the floor actually matters, and
+    checks the plumbing doesn't break the same robust B->C recovery as the other
+    consensus test above.
+    """
+    data, arm_labels, clamped_nodes, indra_priors = _chain_data_with_intervention_arm(
+        seed=4, n_obs=80, n_clamp=8
+    )
+    allowed_edges = {("A", "B"), ("B", "A"), ("B", "C"), ("C", "B")}
+
+    y0_graph = net.estimate_posterior_dag(
+        data.copy(),
+        indra_priors,
+        prior_strength=5.0,
+        scoring_function=pdr.BICGaussIndraPriors,
+        search_algorithm=pdr.SparseHillClimb,
+        n_bootstrap=30,
+        edge_probability=0.5,
+        selection="consensus",
+        interventional=True,
+        arm_labels=arm_labels,
+        clamped_nodes=clamped_nodes,
+        arm_resample_floor=10,
+        verbose=False,
+    )
+    edges = {(str(u), str(v)) for u, v in y0_graph.directed.edges()}
+    assert edges, "expected a non-trivial learned network"
+    assert edges <= allowed_edges, f"unexpected edge(s) outside the prior: {edges - allowed_edges}"
+    assert ("B", "C") in edges
+    assert ("C", "B") not in edges
+
+
+def test_estimate_posterior_dag_consensus_subsample_frac_override():
+    """consensus_subsample_frac overrides consensus's hardcoded subsample_frac=0.65 - added
+    after HPN-DREAM's BT20 contexts (DMSO-only n=5-6) showed a 65% subsample of an already-tiny
+    dataset collapses to too few rows to fit almost any candidate parent set, stalling the
+    bootstrap for hours without finishing. Checks the override reaches run_bootstrap's own
+    subsample_frac argument, and that leaving it unset reproduces the original 0.65 default -
+    both via a call-argument spy rather than actually running the (slow) bootstrap.
+    """
+    from unittest.mock import patch
+
+    data, _, _, indra_priors = _chain_data_with_intervention_arm(seed=4)
+
+    with patch.object(net, "run_bootstrap", wraps=net.run_bootstrap) as spy:
+        net.estimate_posterior_dag(
+            data.copy(), indra_priors, prior_strength=5.0,
+            scoring_function=pdr.BICGaussIndraPriors, search_algorithm=pdr.SparseHillClimb,
+            n_bootstrap=5, edge_probability=0.5, selection="consensus", verbose=False,
+            consensus_subsample_frac=1.0,
+        )
+        assert spy.call_args.kwargs["subsample_frac"] == 1.0
+
+    with patch.object(net, "run_bootstrap", wraps=net.run_bootstrap) as spy:
+        net.estimate_posterior_dag(
+            data.copy(), indra_priors, prior_strength=5.0,
+            scoring_function=pdr.BICGaussIndraPriors, search_algorithm=pdr.SparseHillClimb,
+            n_bootstrap=5, edge_probability=0.5, selection="consensus", verbose=False,
+        )
+        assert spy.call_args.kwargs["subsample_frac"] == 0.65
+
+
+def test_estimate_posterior_dag_default_ignores_interventional_kwargs_path():
+    """No arm_labels/interventional at all - must behave exactly as before this
+    feature existed (same call, no new kwargs reaching the scorer)."""
+    data, _, _, indra_priors = _chain_data_with_intervention_arm(seed=3)
+
+    # Should run to completion without ever touching the interventional branch.
+    y0_graph = net.estimate_posterior_dag(
+        data.copy(),
+        indra_priors,
+        prior_strength=5.0,
+        scoring_function=pdr.BICGaussIndraPriors,
+        search_algorithm=pdr.SparseHillClimb,
+        n_bootstrap=10,
+        edge_probability=0.5,
+        selection="best_of",
+        verbose=False,
+    )
+    assert y0_graph.directed.number_of_nodes() == 3

--- a/tests/test_prior_data_reconciliation.py
+++ b/tests/test_prior_data_reconciliation.py
@@ -377,9 +377,7 @@ def test_bic_gauss_indra_priors_interventional_identifies_chain_orientation():
     reverse_chain = {"C": [], "B": ["C"], "A": ["B"]}
 
     # Observational-only: the two Markov-equivalent hypotheses tie exactly.
-    scorer_obs = pdr.BICGaussIndraPriors(
-        data.loc[arm_labels == "obs"], edge_priors=edge_priors
-    )
+    scorer_obs = pdr.BICGaussIndraPriors(data.loc[arm_labels == "obs"], edge_priors=edge_priors)
     score_true_obs = total_score(scorer_obs, true_chain)
     score_reverse_obs = total_score(scorer_obs, reverse_chain)
     assert score_true_obs == pytest.approx(score_reverse_obs, abs=1e-6)
@@ -424,15 +422,17 @@ def test_resample_with_arm_floor_keeps_small_arm_intact_across_seeds():
     big_arm_varied = False
     for seed in range(20):
         resampled = pdr._resample_with_arm_floor(
-            combined, "__arm_label__", frac=0.65, replace=True, floor=10,
+            combined,
+            "__arm_label__",
+            frac=0.65,
+            replace=True,
+            floor=10,
             rng=np.random.RandomState(seed),
         )
         resampled_small = resampled[resampled["__arm_label__"] == "small"]
         # The small (3-row) arm is below the floor=10 threshold: every one of its
         # rows must appear, unresampled, exactly once, every single time.
-        pd.testing.assert_frame_equal(
-            resampled_small.sort_index(), small_rows.sort_index()
-        )
+        pd.testing.assert_frame_equal(resampled_small.sort_index(), small_rows.sort_index())
         resampled_big = resampled[resampled["__arm_label__"] == "big"]
         # The big (20-row) arm is at/above the floor: it IS bootstrap-resampled,
         # so it should vary across seeds (and not always be all 20 original rows).
@@ -444,7 +444,11 @@ def test_resample_with_arm_floor_keeps_small_arm_intact_across_seeds():
 def test_resample_with_arm_floor_all_arms_above_floor_resamples_everything():
     combined = _combined_big_small(n_big=20, n_small=12)
     resampled = pdr._resample_with_arm_floor(
-        combined, "__arm_label__", frac=0.5, replace=True, floor=10,
+        combined,
+        "__arm_label__",
+        frac=0.5,
+        replace=True,
+        floor=10,
         rng=np.random.RandomState(0),
     )
     # Both arms are >= floor=10, so both get bootstrap-resampled to round(frac*len).

--- a/tests/test_prior_data_reconciliation.py
+++ b/tests/test_prior_data_reconciliation.py
@@ -9,9 +9,16 @@ Covers the deterministic / data-transform helpers only:
   with and without the sigmoid probability conversion.
 - remove_high_corr_edges_from_blacklist: blacklist pruning and prior augmentation
   driven by a small correlation setup.
+- BICGaussIndraPriors.local_score: the observational (default) path is covered by
+  a regression/snapshot test; the opt-in interventional (GIES-style) path is
+  covered separately, including the textbook chain-orientation identifiability
+  case observational scoring cannot resolve.
+- _resample_with_arm_floor: the disabled (floor=0) path matches a plain pooled
+  .sample() call exactly; the enabled path keeps any arm below the floor fully
+  intact across many seeds while still resampling arms at/above it.
 
-The pgmpy scoring classes and the Parallel/HillClimb bootstrap drivers
-(process_bootstrap / run_bootstrap) are heavier and are not exercised here.
+The Parallel/HillClimb bootstrap drivers (process_bootstrap / run_bootstrap) are
+heavier and are not exercised here.
 """
 
 import importlib
@@ -19,6 +26,7 @@ import importlib
 import networkx as nx
 import numpy as np
 import pandas as pd
+import pytest
 
 pdr = importlib.import_module("causomic.graph_construction.prior_data_reconciliation")
 
@@ -212,3 +220,233 @@ def test_remove_high_corr_edges_from_blacklist_keeps_low_corr():
     )
     # Correlation below threshold: blacklist edge is preserved.
     assert ("A", "B") in updated_blacklist
+
+
+# ---------------------------------------------------------------------------
+# BICGaussIndraPriors.local_score - interventional (GIES-style) scoring
+# ---------------------------------------------------------------------------
+def test_bic_gauss_indra_priors_observational_regression():
+    """interventional=False (the default) must reproduce local_score's behavior
+    from before the interventional branch existed, exactly. Also covers the
+    documented fallback: interventional=True with no arm_labels must give the
+    identical value, since arm_labels is what actually gates the new branch.
+    """
+    data = pd.DataFrame(
+        {
+            "X": [1.0, 2.0, 3.0, 4.0, 5.0, 2.5, 3.5, 1.5],
+            "Y": [2.1, 3.9, 6.2, 7.8, 10.1, 5.0, 7.1, 3.0],
+            "Z": [0.5, 1.5, 1.0, 2.5, 3.0, 1.2, 2.0, 0.8],
+        }
+    )
+    edge_priors = {("X", "Y"): 0.8, ("Z", "Y"): 0.3}
+
+    scorer_default = pdr.BICGaussIndraPriors(data, edge_priors=edge_priors, prior_strength=2.0)
+    score_default = scorer_default.local_score("Y", ["X", "Z"])
+
+    # Snapshot value - computed once from this exact implementation. A future
+    # change that silently alters the observational code path should break this.
+    assert score_default == pytest.approx(4.747972022632462)
+
+    scorer_flag_only = pdr.BICGaussIndraPriors(
+        data, edge_priors=edge_priors, prior_strength=2.0, interventional=True
+    )
+    score_flag_only = scorer_flag_only.local_score("Y", ["X", "Z"])
+    assert score_flag_only == score_default
+
+
+def test_bic_gauss_indra_priors_clamped_parent_still_usable_as_regressor():
+    """A node clamped in an arm is only dropped from ITS OWN local-score
+    contribution in that arm - it must remain a real, informative regressor for
+    other nodes' scores there. Isolate this with a single all-clamped arm: if
+    B's clamped values were (incorrectly) ignored as a C regressor, C|[B] would
+    score no better than C|[] despite the strong true B->C relationship built
+    into the data.
+    """
+    rng = np.random.default_rng(3)
+    n = 100
+    b_vals = rng.uniform(-3, 3, n)
+    c_vals = 2.0 * b_vals + rng.normal(0, 0.1, n)
+    data = pd.DataFrame({"B": b_vals, "C": c_vals})
+    arm_labels = pd.Series(["clampB"] * n, index=data.index)
+    clamped_nodes = {"clampB": ["B"]}
+
+    scorer = pdr.BICGaussIndraPriors(
+        data,
+        edge_priors={("B", "C"): 0.5},
+        interventional=True,
+        arm_labels=arm_labels,
+        clamped_nodes=clamped_nodes,
+    )
+    score_with_b = scorer.local_score("C", ["B"])
+    score_without_b = scorer.local_score("C", [])
+    assert score_with_b > score_without_b + 10  # clear margin, not a coin-flip tie
+
+
+def test_bic_gauss_indra_priors_variable_clamped_in_every_arm_returns_neg_inf():
+    data = pd.DataFrame({"A": [1.0, 2.0, 3.0], "B": [2.0, 4.0, 6.0]})
+    arm_labels = pd.Series(["only_arm"] * 3, index=data.index)
+    clamped_nodes = {"only_arm": ["A"]}
+
+    scorer = pdr.BICGaussIndraPriors(
+        data,
+        edge_priors={("B", "A"): 0.5},
+        interventional=True,
+        arm_labels=arm_labels,
+        clamped_nodes=clamped_nodes,
+    )
+    # A is clamped in the only arm that exists, so there is no data anywhere in
+    # which A's value reflects a response to its hypothesized parent B.
+    assert scorer.local_score("A", ["B"]) == -np.inf
+
+
+def test_bic_gauss_indra_priors_mismatched_df_model_across_arms_returns_neg_inf():
+    """Regression test for a real failure hit running this against the HPN-DREAM
+    pilot's actual arms (6 rows before any resampling): a bootstrap resample of
+    a small arm can leave too few rows to estimate the full parent set, so
+    statsmodels' GLM fit there is rank-deficient and reports a SMALLER df_model
+    than a well-powered arm - previously a hard `assert` on this raised
+    AssertionError, which propagates through joblib and aborts an entire
+    Parallel(...) bootstrap run for every worker, not just the offending one.
+    Must return -inf (a degenerate-fit signal, like any other singular fit)
+    instead of raising.
+    """
+    rng = np.random.default_rng(0)
+    n_big, n_tiny = 20, 2
+    data = pd.DataFrame(
+        {
+            "P1": np.concatenate([rng.normal(0, 1, n_big), rng.normal(0, 1, n_tiny)]),
+            "P2": np.concatenate([rng.normal(0, 1, n_big), rng.normal(0, 1, n_tiny)]),
+            "Y": np.concatenate([rng.normal(0, 1, n_big), rng.normal(0, 1, n_tiny)]),
+        }
+    )
+    arm_labels = pd.Series(["big"] * n_big + ["tiny"] * n_tiny, index=data.index)
+    edge_priors = {("P1", "Y"): 0.5, ("P2", "Y"): 0.5}
+
+    scorer = pdr.BICGaussIndraPriors(
+        data, edge_priors=edge_priors, interventional=True, arm_labels=arm_labels, clamped_nodes={}
+    )
+    # Must not raise - the 2-row "tiny" arm can't identify both P1 and P2's
+    # coefficients (2 predictors + intercept from 2 points), so its df_model
+    # differs from the well-powered "big" arm's.
+    assert scorer.local_score("Y", ["P1", "P2"]) == -np.inf
+
+
+def test_bic_gauss_indra_priors_interventional_identifies_chain_orientation():
+    """The textbook Markov-equivalence case: a chain A->B->C and its reverse
+    C->B->A share the same skeleton and no v-structures, so they encode the same
+    joint distribution and get IDENTICAL total observational BIC scores - no
+    amount of purely observational data can prefer one over the other.
+
+    Clamping the middle node B breaks the tie: in the arm where B is
+    experimenter-set, the true model's B->C edge still shows up (C responds to
+    the clamped B value) but the reverse model's B->A edge does not (A was
+    generated independently of the clamped B value) - because A is never
+    clamped, its own local score still incorporates that arm's rows, so the
+    "A depends on B" hypothesis is penalized by data that doesn't support it,
+    which the true "C depends on B" hypothesis is not.
+    """
+    rng = np.random.default_rng(0)
+    n_obs, n_clamp = 150, 150
+
+    # Observational arm: true generative chain A -> B -> C.
+    a_obs = rng.normal(0, 1, n_obs)
+    b_obs = 1.5 * a_obs + rng.normal(0, 0.5, n_obs)
+    c_obs = 1.5 * b_obs + rng.normal(0, 0.5, n_obs)
+
+    # Interventional arm: B clamped to experimenter-chosen values, independent
+    # of A; the real B -> C mechanism still operates on whatever value B takes.
+    a_clamp = rng.normal(0, 1, n_clamp)
+    b_clamp = rng.uniform(-3, 3, n_clamp)
+    c_clamp = 1.5 * b_clamp + rng.normal(0, 0.5, n_clamp)
+
+    data = pd.DataFrame(
+        {
+            "A": np.concatenate([a_obs, a_clamp]),
+            "B": np.concatenate([b_obs, b_clamp]),
+            "C": np.concatenate([c_obs, c_clamp]),
+        }
+    )
+    arm_labels = pd.Series(["obs"] * n_obs + ["clampB"] * n_clamp, index=data.index)
+    clamped_nodes = {"clampB": ["B"]}
+    edge_priors = {(p, v): 0.5 for p in ["A", "B", "C"] for v in ["A", "B", "C"] if p != v}
+
+    def total_score(scorer, edges_by_node):
+        return sum(scorer.local_score(v, parents) for v, parents in edges_by_node.items())
+
+    true_chain = {"A": [], "B": ["A"], "C": ["B"]}
+    reverse_chain = {"C": [], "B": ["C"], "A": ["B"]}
+
+    # Observational-only: the two Markov-equivalent hypotheses tie exactly.
+    scorer_obs = pdr.BICGaussIndraPriors(
+        data.loc[arm_labels == "obs"], edge_priors=edge_priors
+    )
+    score_true_obs = total_score(scorer_obs, true_chain)
+    score_reverse_obs = total_score(scorer_obs, reverse_chain)
+    assert score_true_obs == pytest.approx(score_reverse_obs, abs=1e-6)
+
+    # Interventional: clamping B breaks the tie decisively in favor of the truth.
+    scorer_int = pdr.BICGaussIndraPriors(
+        data,
+        edge_priors=edge_priors,
+        interventional=True,
+        arm_labels=arm_labels,
+        clamped_nodes=clamped_nodes,
+    )
+    score_true_int = total_score(scorer_int, true_chain)
+    score_reverse_int = total_score(scorer_int, reverse_chain)
+    assert score_true_int > score_reverse_int + 100  # decisive, not marginal
+
+
+# ---------------------------------------------------------------------------
+# _resample_with_arm_floor
+# ---------------------------------------------------------------------------
+
+
+def _combined_big_small(n_big=20, n_small=3):
+    combined = pd.DataFrame({"x": np.arange(n_big + n_small, dtype=float)})
+    combined["__arm_label__"] = ["big"] * n_big + ["small"] * n_small
+    return combined
+
+
+def test_resample_with_arm_floor_disabled_matches_plain_sample():
+    combined = _combined_big_small()
+    got = pdr._resample_with_arm_floor(
+        combined, "__arm_label__", frac=0.65, replace=True, floor=0, rng=np.random.RandomState(0)
+    )
+    want = combined.sample(frac=0.65, replace=True, random_state=np.random.RandomState(0))
+    pd.testing.assert_frame_equal(got, want)
+
+
+def test_resample_with_arm_floor_keeps_small_arm_intact_across_seeds():
+    combined = _combined_big_small(n_big=20, n_small=3)
+    small_rows = combined[combined["__arm_label__"] == "small"]
+
+    big_arm_varied = False
+    for seed in range(20):
+        resampled = pdr._resample_with_arm_floor(
+            combined, "__arm_label__", frac=0.65, replace=True, floor=10,
+            rng=np.random.RandomState(seed),
+        )
+        resampled_small = resampled[resampled["__arm_label__"] == "small"]
+        # The small (3-row) arm is below the floor=10 threshold: every one of its
+        # rows must appear, unresampled, exactly once, every single time.
+        pd.testing.assert_frame_equal(
+            resampled_small.sort_index(), small_rows.sort_index()
+        )
+        resampled_big = resampled[resampled["__arm_label__"] == "big"]
+        # The big (20-row) arm is at/above the floor: it IS bootstrap-resampled,
+        # so it should vary across seeds (and not always be all 20 original rows).
+        if len(resampled_big) != 20 or not resampled_big["x"].is_monotonic_increasing:
+            big_arm_varied = True
+    assert big_arm_varied, "expected the big arm's resample to vary across seeds"
+
+
+def test_resample_with_arm_floor_all_arms_above_floor_resamples_everything():
+    combined = _combined_big_small(n_big=20, n_small=12)
+    resampled = pdr._resample_with_arm_floor(
+        combined, "__arm_label__", frac=0.5, replace=True, floor=10,
+        rng=np.random.RandomState(0),
+    )
+    # Both arms are >= floor=10, so both get bootstrap-resampled to round(frac*len).
+    assert len(resampled[resampled["__arm_label__"] == "big"]) == round(0.5 * 20)
+    assert len(resampled[resampled["__arm_label__"] == "small"]) == round(0.5 * 12)

--- a/tests/test_proteomics_simulator.py
+++ b/tests/test_proteomics_simulator.py
@@ -125,8 +125,13 @@ def test_simulate_data_intervention_propagates_to_direct_child():
     """
     G = chain_graph()
     out = ps.simulate_data(
-        G, coefficients=_chain_coefficients(), n=5000, seed=1,
-        intervention={"Y": 40.0}, add_feature_var=False, verbose=False,
+        G,
+        coefficients=_chain_coefficients(),
+        n=5000,
+        seed=1,
+        intervention={"Y": 40.0},
+        add_feature_var=False,
+        verbose=False,
     )
     expected_z = 5.0 + 0.8 * (40.0 - 10.0)  # Y's baseline intercept is 10.0
     assert np.isclose(out["Protein_data"]["Y"].mean(), 40.0)
@@ -142,8 +147,13 @@ def test_simulate_data_intervention_propagates_through_grandchild():
     """
     G = chain_graph()
     out = ps.simulate_data(
-        G, coefficients=_chain_coefficients(), n=5000, seed=1,
-        intervention={"X": 30.0}, add_feature_var=False, verbose=False,
+        G,
+        coefficients=_chain_coefficients(),
+        n=5000,
+        seed=1,
+        intervention={"X": 30.0},
+        add_feature_var=False,
+        verbose=False,
     )
     expected_y = 10.0 + 1.5 * (30.0 - 20.0)  # X's baseline intercept is 20.0
     expected_z = 5.0 + 0.8 * (expected_y - 10.0)

--- a/tests/test_proteomics_simulator.py
+++ b/tests/test_proteomics_simulator.py
@@ -108,6 +108,50 @@ def test_simulate_data_intervention_pins_node():
     assert np.allclose(out["Protein_data"]["X"], 7.0)
 
 
+def _chain_coefficients():
+    return {
+        "X": {"intercept": 20.0, "error": 1.0},
+        "Y": {"X": 1.5, "intercept": 10.0, "error": 1.0},
+        "Z": {"Y": 0.8, "intercept": 5.0, "error": 1.0},
+    }
+
+
+def test_simulate_data_intervention_propagates_to_direct_child():
+    """A clamped parent's shift must reach its child. Regression test: a child
+    used to center its clamped parent on that parent's OWN (post-clamp,
+    constant) batch mean, which trivially equals the clamp value and so
+    canceled the shift regardless of its magnitude - Z tracked its own
+    unshifted intercept no matter what Y was clamped to.
+    """
+    G = chain_graph()
+    out = ps.simulate_data(
+        G, coefficients=_chain_coefficients(), n=5000, seed=1,
+        intervention={"Y": 40.0}, add_feature_var=False, verbose=False,
+    )
+    expected_z = 5.0 + 0.8 * (40.0 - 10.0)  # Y's baseline intercept is 10.0
+    assert np.isclose(out["Protein_data"]["Y"].mean(), 40.0)
+    assert np.isclose(out["Protein_data"]["Z"].mean(), expected_z, atol=0.2)
+
+
+def test_simulate_data_intervention_propagates_through_grandchild():
+    """The shift must survive a second hop (X clamped; Z is X's grandchild,
+    not X's own child) - catches a narrower fix that only special-cased a
+    DIRECTLY clamped parent and still canceled the shift one hop further out,
+    since Y (not itself in `intervention`) was still centered on its own
+    (now-shifted) batch mean when generating Z.
+    """
+    G = chain_graph()
+    out = ps.simulate_data(
+        G, coefficients=_chain_coefficients(), n=5000, seed=1,
+        intervention={"X": 30.0}, add_feature_var=False, verbose=False,
+    )
+    expected_y = 10.0 + 1.5 * (30.0 - 20.0)  # X's baseline intercept is 20.0
+    expected_z = 5.0 + 0.8 * (expected_y - 10.0)
+    assert np.isclose(out["Protein_data"]["X"].mean(), 30.0)
+    assert np.isclose(out["Protein_data"]["Y"].mean(), expected_y, atol=0.2)
+    assert np.isclose(out["Protein_data"]["Z"].mean(), expected_z, atol=0.3)
+
+
 # --------------------------------------------------------------------------- #
 # Lower-level helpers
 # --------------------------------------------------------------------------- #

--- a/tests/test_utils_nx.py
+++ b/tests/test_utils_nx.py
@@ -198,3 +198,74 @@ def test_query_forward_paths_counts_mediators_not_edges():
         ("A", "B"),
         ("B", "C"),
     }
+
+
+def _make_weak_chain_graph():
+    # A -> B -> C, each edge with weak evidence (2) that only clears a
+    # depth-1 (1-mediator) threshold of 1, not a depth-0 (direct) threshold
+    # of 5.
+    G = nx.DiGraph()
+    for u, v in [("A", "B"), ("B", "C")]:
+        G.add_edge(
+            u,
+            v,
+            evidence={
+                "total_evidence": 2,
+                "source_evidence": 1,
+                "stmt_type": ["IncreaseAmount"],
+            },
+        )
+    return G
+
+
+def test_query_forward_paths_default_excludes_other_start_as_mediator():
+    # Regression/documentation: when start_nodes == end_nodes (the
+    # closed-neighborhood case), the default exclude_other_starts=True drops
+    # every other list member as a candidate mediator for a given pair, so a
+    # real A->B->C relationship that only clears the threshold at the
+    # 1-mediator depth is missed entirely: the (A, B) and (B, C) rounds
+    # reject it at their own direct (depth-0) threshold, and the (A, C)
+    # round can't route through the excluded node B.
+    G = _make_weak_chain_graph()
+    nodes = ["A", "B", "C"]
+
+    result = utils_nx.query_forward_paths(
+        G,
+        start_nodes=nodes,
+        end_nodes=nodes,
+        n_mediators=1,
+        med_ev_filter=[5, 1],
+    )
+    assert result.empty
+
+
+def test_query_neighborhood_paths_allows_internal_mediators():
+    # Same graph/thresholds as above, but via query_neighborhood_paths
+    # (exclude_other_starts=False): B is now a valid mediator between A and
+    # C, so both edges on the chain are recovered.
+    G = _make_weak_chain_graph()
+    nodes = ["A", "B", "C"]
+
+    result = utils_nx.query_neighborhood_paths(
+        G,
+        nodes,
+        n_mediators=1,
+        med_ev_filter=[5, 1],
+    )
+    assert set(zip(result["source"], result["target"])) == {
+        ("A", "B"),
+        ("B", "C"),
+    }
+
+    # Equivalent to calling query_forward_paths directly with the flag off.
+    direct = utils_nx.query_forward_paths(
+        G,
+        start_nodes=nodes,
+        end_nodes=nodes,
+        n_mediators=1,
+        med_ev_filter=[5, 1],
+        exclude_other_starts=False,
+    )
+    assert set(zip(direct["source"], direct["target"])) == set(
+        zip(result["source"], result["target"])
+    )


### PR DESCRIPTION
Support finding all pairwise INDRA relations within a single node set (query_neighborhood_paths), not just between distinct start/end groups, plus related updates to network construction, proteomics simulation, and prior/data reconciliation used by the HPN-DREAM validation work.